### PR TITLE
Fix and enable records again

### DIFF
--- a/builds/latest.lua
+++ b/builds/latest.lua
@@ -1434,6 +1434,965 @@ local function initialize_parkour() -- so it uses less space after building
 	}
 	--[[ End of file modes/parkour/filemanagers.lua ]]--
 	--[[ Directory translations/parkour ]]--
+	--[[ File translations/parkour/cn.lua ]]--
+	translations.cn = {
+		name = "cn",
+		fullname = "中文",
+
+		-- Error messages
+		corrupt_map = "<r>地圖崩壞。正在載入另一張。",
+		corrupt_map_vanilla = "<r>[錯誤] <n>無法取得此地圖的資訊。",
+		corrupt_map_mouse_start = "<r>[錯誤] <n>此地圖需要有起始位置 (小鼠出生點)。",
+		corrupt_map_needing_chair = "<r>[錯誤] <n>地圖需要包括終點椅子。",
+		corrupt_map_missing_checkpoints = "<r>[錯誤] <n>地圖需要有最少一個重生點 (黃色釘子)。",
+		corrupt_data = "<r>不幸地, 你的資料崩壞了而被重置了。",
+		min_players = "<r>房間裡需要至少4名玩家才可以保存資料。 <bl>[%s/%s]",
+		tribe_house = "<r>在部落之家遊玩的資料不會被儲存。",
+		invalid_syntax = "<r>無效的格式。",
+		code_error = "<r>發生了錯誤: <bl>%s-%s-%s %s",
+		emergency_mode = "<r>正在啟動緊急終止模式, 新玩家無法加入遊戲。請前往另一個　#parkour 房間。",
+		leaderboard_not_loaded = "<r>排行榜沒被加載。請稍後片刻。",
+		max_power_keys = "<v>[#] <r>你只可以在同一個按鍵使用最多 %s 個能力。",
+
+		-- Help window
+		help = "幫助",
+		staff = "職員",
+		rules = "規則",
+		contribute = "貢獻",
+		changelog = "新聞",
+		help_help = "<p align = 'center'><font size = '14'>歡迎來到 <T>#parkour!</T></font></p>\n<font size = '12'><p align='center'><J>你的目標是到達所有重生點直到完成地圖。</J></p>\n\n<N>• 按 <O>O</O>鍵, 輸入 <O>!op</O> 或是點擊右上方的 <O>齒輪</O> 來開啟 <T>選項目錄</T>。\n• 按 <O>P</O> 鍵或是點擊右上方的 <O>拳頭標誌</O> 來開啟 <T>能力目錄</T>。\n• 按 <O>L</O> 鍵或是輸入 <O>!lb</O> 來開啟 <T>排行榜</T>。\n• 按 <O>M</O> 鍵或是 <O>刪除</O> 鍵來 <T>自殺</T>, 你可以在 <J>選項</J> 目錄中激活按鍵。\n• 要知道更多關於我們 <O>職員</O> 的資訊以及 <O>parkour 的規則</O>, 可點擊 <T>職員</T> 及 <T>規則</T> 的分頁查看。\n• 點擊 <a href='event:discord'><o>這裡</o></a> 來取得 discord 邀請連結及 <a href='event:map_submission'><o>這裡</o></a> 來得到提交地圖的論壇連結。\n• 當你想滾動頁面可使用 <o>上</o> 鍵及 <o>下</o> 鍵。\n\n<p align = 'center'><font size = '13'><T>貢獻現在是開放的! 點擊 <O>貢獻</O> 分頁來了解更多!</T></font></p>",
+		help_staff = "<p align = 'center'><font size = '13'><r>免責聲明: Parkour 的職員並不是 Transformice 職員而且在遊戲裡沒有任何權力, 只負責這小遊戲的規管。</r>\nParkour 職員確保小遊戲減少錯誤而運作順暢, 而且可以在有需要時協助玩家。</font></p>\n你可以在聊天框輸入 <D>!staff</D> 來查看職員列表。\n\n<font color = '#E7342A'>工作人員:</font> 他們負責透過更新及修復滴漏洞來維護小遊戲。\n\n<font color = '#D0A9F0'>小隊主管:</font> 他們會觀察管理團隊及地圖團隊, 確保他們在工作上的表現。他們也負責招募新成員加入職員團隊中。\n\n<font color = '#FFAAAA'>管理員:</font> 他們負責執行小遊戲裡的規則以及處分違反規則的玩家。\n\n<font color = '#25C059'>地圖管理員:</font> 他們負責審核, 新增, 以及移除小遊戲裡的地圖來確保你可以享受遊戲過程。",
+		help_rules = "<font size = '13'><B><J>所有適用於 Transformice 的條款及細則也適用於 #parkour</J></B></font>\n\n如果你發現任何玩家違反這些規則, 可以在遊戲中私聊 parkour 的管理員。如果沒有管理員在線, 你可以在 discord 伺服器中舉報事件。\n當你舉報的時候, 請提供你所在的伺服器, 房間名稱, 以及玩家名稱。\n• 例如: en-#parkour10 Blank#3495 trolling\n證明, 例如是截圖, 錄象以及gif圖能有效協助舉報, 但不是一定需要的。\n\n<font size = '11'>• 任何 <font color = '#ef1111'>外掛, 瑕疵或漏洞</font> 是不能在 #parkour 房間中使用\n• <font color = '#ef1111'>VPN 刷數據</font> 會被當作 <B>利用漏洞</B> 而不被允許的。 <p align = 'center'><font color = '#cc2222' size = '12'><B>\n任何人被抓到違反規則會被即時封禁。</B></font></p>\n\n<font size = '12'>Transformice 允許搗蛋行為。但是, <font color='#cc2222'><B>我們不允許在 parkour 的搗蛋行為。</B></font></font>\n\n<p align = 'center'><J>惡作劇是指一個玩家有意圖地使用能力或消耗品來阻止其他玩家完成地圖。</j></p>\n• 復仇性的搗蛋行為 <B>並不是一個合理解釋</B> 來搗亂別人而因此你也會被處分。\n• 強迫想自理的玩家接受協助而當他說不用之後仍舊沒有停止此行為也會被視作搗蛋。\n• <J>如果一個玩家不想被協助或是想自理通關, 請你盡力協助其他玩家。</J> 但是如果有另外的玩家需要協助而剛好跟自理玩家在同一個重生點, 你可以協助他們 [兩人]。\n\n如果玩家惡作劇被抓, 會被處分基於時間的懲罰。重覆的搗蛋行為會引至更長及更嚴重的處分。",
+		help_contribute = "<font size='14'>\n<p align='center'>Parkour 管理團隊喜愛開放原始碼是因為它能夠<t>協助社群</t>。 你可以在 <o><u><a href='event:github'>GitHub</a></u></o> <o>查看</o> 以及 <o>修改</o> 原始碼。\n\n維護這個小遊戲是 <t>義務性質</t>, 所以任何在 <t>編程</t>, <t>漏洞回饋</t>, <t>建議</t> 及 <t>地圖創作</t> 上提供的幫助將會是十分 <u>歡迎而且非常感激</u>。\n你可以在 <o><u><a href='event:discord'>Discord</a></u></o> 及/或 <o><u><a href='event:github'>GitHub</a></u></o> <vp>匯報漏洞</vp> 和 <vp>提供意見</vp>。\n你可以在我們的 <o><u><a href='event:map_submission'>論壇帖子</a></u></o> 中 <vp>提交你的地圖</vp>。\n\n維護 Parkour 不是很花費, 但也不完全是免費。我們希望你能夠在 <o><u><a href='event:donate'>這裡</a></u></o> <t>捐贈任何金額</t> 來支持我們。\n<u>所有捐款會用來改善這個小遊戲。</u></p>",
+		help_changelog = "<font size='13'><p align='center'><o>Version 2.10.0 - 17/04/2021</o></p>\n\n<font size='11'>• <font size='13'><b><j>三個</J></b> 全新的 Transformice 稱號只可以在<font color='#1A7EC9'><b>#parkour</b></font>遊玩而解鎖!</font>\n• 在個資中加入兩項新的資訊。\n• 調整細微文字格式。",
+
+		-- Congratulation messages
+		reached_level = "<d>恭喜! 你到達了第 <vp>%s</vp> 個重生點。 (<t>%ss</t>)",
+		finished = "<d><o>%s</o> 在 <vp>%s</vp> 秒內完成了地圖, <fc>恭喜!",
+		unlocked_power = "<ce><d>%s</d> 解鎖了 <vp>%s</vp> 能力。",
+
+		-- Information messages
+		staff_power = "<r>Parkour 職員 <b>不會</b> 擁有任何在 #parkour 房間以外的權力。",
+		donate = "<vp>如果你想為此小遊戲捐款，請輸入<b>!donate</b>！",
+		paused_events = "<cep><b>[警告!]</b> <n>小遊戲已達到最高流量限制而被暫停了。",
+		resumed_events = "<n2>小遊戲已繼續啟用。",
+		welcome = "<n>歡迎來到 <t>#parkour</t>!",
+		module_update = "<r><b>[警告!]</b> <n>小遊戲將會在 <d>%02d:%02d</d> 後更新。",
+		leaderboard_loaded = "<j>排行榜已載入。請按 L 鍵打開它。",
+		kill_minutes = "<R>你的能力已經在 %s 分鐘內暫時取消了。",
+		permbanned = "<r>你已經在 #parkour 被永久封禁。",
+		tempbanned = "<r>你已經在 #parkour 被封禁了 %s 分鐘。",
+		forum_topic = "<rose>更多關於這個小遊戲的資訊可以查看: %s",
+		report = "<j>想舉報玩家? <t><b>/c Parkour#8558 .report 玩家名字#0000</b></t>",
+
+		-- Easter Eggs
+		easter_egg_0  = "<ch>所以要開始倒數了...",
+		easter_egg_1  = "<ch>剩下時間少於 24 小時!",
+		easter_egg_2  = "<ch>哇, 你挺早的! 你是不是太興奮了?",
+		easter_egg_3  = "<ch>一個驚喜在等待你...",
+		easter_egg_4  = "<ch>你知道接下來將會發生什麼...?",
+		easter_egg_5  = "<ch>時間滴答滴答在過著...",
+		easter_egg_6  = "<ch>驚喜快要到了!",
+		easter_egg_7  = "<ch>派對很快要開始...",
+		easter_egg_8  = "<ch>查看你的時鐘, 是時候了嗎?",
+		easter_egg_9  = "<ch>注意, 時間在一直走...",
+		easter_egg_10 = "<ch>坐下來放鬆一下, 馬上就到明天了!",
+		easter_egg_11 = "<ch>一起早點到床上, 會使時間過得更快!",
+		easter_egg_12 = "<ch>最重要是耐心",
+		easter_egg_13 = "<ch>https://youtu.be/9jK-NcRmVcw",
+		double_maps = "<bv>雙倍地圖計算將會在星期六 (GMT+2) 開始, 而且所有能力都可以在這 parkour 生日週使用!",
+		double_maps_start = "<rose>這週是 PARKOUR 的生日! 雙倍地圖計算而且所有能力都已被激活使用。感謝跟我們一起遊玩!",
+		double_maps_end = "<rose>Parkour 的生日週已完結。感謝各位的遊玩!",
+
+		-- Records
+		records_enabled = "<v>[#] <d>記錄模式已在這房間啟用。數據不會被記錄而且不能使用能力!\n你可以在這裡查看更多關於記錄模式的資訊: <b>%s</b>",
+		records_admin = "<v>[#] <d>你是這房間的管理員。你可以使用以下指令 <b>!map</b>, <b>!setcp</b>, <b>!pw</b> and <b>!time</b>。",
+		records_completed = "<v>[#] <d>你已經完成了地圖! 如果你想重新嘗試, 可輸入 <b>!redo</b>。",
+		records_submit = "<v>[#] <d>哇! 看來你達成了房間裡最快的通關時間。如果你希望提交你的記錄, 可輸入 <b>!submit</b>。",
+		records_invalid_map = "<v>[#] <r>看來這張地圖並不在 parkour 的循環裡... 你不能提交這地圖的記錄!",
+		records_not_fastest = "<v>[#] <r>看來你並不是房間裡最快通關的玩家...",
+		records_already_submitted = "<v>[#] <r>你已經提交了這地圖的通關時間記錄!",
+		records_submitted = "<v>[#] <d>你在地圖 <b>%s</b> 的時間記錄已被提交。",
+
+		-- Miscellaneous
+		mod_apps = "<j>Parkour 管理員申請現正開放! 請查看這連結: <rose>%s",
+		afk_popup = "\n<p align='center'><font size='30'><bv><b>你正在掛機模式</b></bv>\n隨意移動來復活</font>\n\n<font size='30'><u><t>提示:</t></u></font>\n\n<font size='15'><r>玩家頭上的紅線表示他們不想被協助!\n在parkour惡作劇/阻礙其他玩家通關是不被允許的!<d>\n加入我們的 <cep><a href='event:discord'>discord 伺服器</a></cep>!\n想在編程上貢獻? 查看 <cep><a href='event:github'>github 編程庫</a></cep> 吧。\n你有好的地圖想提交嗎? 在我們的 <cep><ahref='event:map_submission'>地圖提交帖子</a></cep> 上留言吧。\n查看我們的 <cep><a href='event:forum'>官方帖子</a></cep> 來得到更多資訊!\n透過 <cep><a href='event:donate'>捐款</a></cep> 支持我們吧!",
+		options = "<p align='center'><font size='20'>Parkour 選項</font></p>\n\n使用 <b>QWERTY</b> 鍵盤 (使用<b>AZERTY</b>請關閉此項)\n\n使用快捷鍵 <b>M</b> 來 <b>自殺</b> (使用<b>DEL</b>請關閉此項)\n\n顯示你的能力緩衝時間\n\n顯示能力選項按鈕\n\n顯示幫助按鈕\n\n顯示完成地圖的公告\n\n顯示不用被幫助的標示",
+		cooldown = "<v>[#] <r>請等候幾秒再重新嘗試。",
+		power_options = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><b>QWERTY</b> 鍵盤" ..
+						 "\n\n<b>隱藏</b> 地圖通過數" ..
+						 "\n\n使用 <b>預設鍵</b>"),
+		unlock_power = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>完成 <v>%s</v> 張地圖" ..
+						"<font size='5'>\n\n</font>來解鎖" ..
+						"<font size='5'>\n\n</font><v>%s</v>"),
+		upgrade_power = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>完成 <v>%s</v> 張地圖" ..
+						"<font size='5'>\n\n</font>來升級到" ..
+						"<font size='5'>\n\n</font><v>%s</v>"),
+		unlock_power_rank = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>階級 <v>%s</v>" ..
+						"<font size='5'>\n\n</font>來解鎖" ..
+						"<font size='5'>\n\n</font><v>%s</v>"),
+		upgrade_power_rank = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>階級 <v>%s</v>" ..
+						"<font size='5'>\n\n</font>來升級到" ..
+						"<font size='5'>\n\n</font><v>%s</v>"),
+		maps_info = ("<p align='center'><font size='13' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
+					 "<font size='5'>\n\n</font>完成地圖數"),
+		overall_info = ("<p align='center'><font size='13' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
+						"<font size='5'>\n\n</font>整體排行榜"),
+		weekly_info = ("<p align='center'><font size='13' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
+					   "<font size='5'>\n\n</font>每周排行榜"),
+		badges = "<font size='14' face='Lucida Console,Liberation Mono,Courier New,Verdana'>徽章 (%s): <a href='event:_help:badge'><j>[?]</j></a>",
+		private_maps = "<bl>玩家的地圖通過數已設定為私人。 <a href='event:_help:private_maps'><j>[?]</j></a></bl>\n",
+		profile = ("<font size='12' face='Lucida Console,Liberation Mono,Courier New,Verdana'>%s%s %s\n\n" ..
+					"整體排行榜名次: <b><v>%s</v></b>\n\n" ..
+					"每周排行榜名次: <b><v>%s</v></b>\n\n%s"),
+		map_count = "地圖通過數: <b><v>%s</v> / <a href='event:_help:yellow_maps'><j>%s</j></a> / <a href='event:_help:red_maps'><r>%s</r></a></b>",
+		title_count = ("<b><j>«!»</j></b> 完成地圖次數: <b><a href='event:_help:map_count_title'><v>%s</v></a></b>\n\n" ..
+					"<b><j>«!»</j></b> 到達重生點次數: <b><a href='event:_help:checkpoint_count_title'><v>%s</v></a></b>"),
+		help_badge = "徽章是玩家可以得到的成就。點擊它們查看介紹。",
+		help_private_maps = "這玩家不想公開分享他的地圖通過數! 你也可以在個人資料中設定隱藏。",
+		help_yellow_maps = "黃色標示的地圖是這周完成了的地圖。",
+		help_red_maps = "紅色標示的地圖是過去一小時內完成了的地圖。",
+		help_map_count_title = "你可以透過完成 parkour 地圖獲得 <b>Transformice</b> 稱號!",
+		help_checkpoint_count_title = "你可以透過到達 parkour 裡所有重生點獲得  <b>Transformice</b> 稱號!",
+		help_badge_1 = "這玩家曾經是parkour 的職員。",
+		help_badge_2 = "這玩家是或曾經達成在整體排行榜的第 1 頁上。",
+		help_badge_3 = "這玩家是或曾經達成在整體排行榜的第 2 頁以上。",
+		help_badge_4 = "這玩家是或曾經達成在整體排行榜的第 3 頁以上。",
+		help_badge_5 = "這玩家是或曾經達成在整體排行榜的第 4 頁以上。",
+		help_badge_6 = "這玩家是或曾經達成在整體排行榜的第 5 頁以上。",
+		help_badge_7 = "這玩家曾經在每周排行榜中得到前三名。",
+		help_badge_8 = "這玩家達成了在一小時內通過 30 張地圖的記錄。",
+		help_badge_9 = "這玩家達成了在一小時內通過 35 張地圖的記錄。",
+		help_badge_10 = "這玩家達成了在一小時內通過 40 張地圖的記錄。",
+		help_badge_11 = "這玩家達成了在一小時內通過 45 張地圖的記錄。",
+		help_badge_12 = "這玩家達成了在一小時內通過 50 張地圖的記錄。",
+		help_badge_13 = "這玩家達成了在一小時內通過 55 張地圖的記錄。",
+		help_badge_14 = "這玩家已經在官方 parkour discord 伺服器上驗證了帳戶 (輸入 <b>!discord</b>)。",
+		help_badge_15 = "這玩家以最快的時間完成了 1 張地圖。",
+		help_badge_16 = "這玩家以最快的時間完成了 5 張地圖。",
+		help_badge_17 = "這玩家以最快的時間完成了 10 張地圖。",
+		help_badge_18 = "這玩家以最快的時間完成了 15 張地圖。",
+		help_badge_19 = "這玩家以最快的時間完成了 20 張地圖。",
+		help_badge_20 = "這玩家以最快的時間完成了 25 張地圖。",
+		help_badge_21 = "這玩家以最快的時間完成了 30 張地圖。",
+		help_badge_22 = "這玩家以最快的時間完成了 35 張地圖。",
+		help_badge_23 = "這玩家以最快的時間完成了 40 張地圖。",
+		make_public = "設定為公開",
+		make_private = "設定為私人",
+		moderators = "管理員",
+		mappers = "地圖管理員",
+		managers = "小隊主管",
+		administrators = "工作人員",
+		close = "關閉",
+		cant_load_bot_profile = "<v>[#] <r>你不能查看這機器人的個人資料因為 #parkour 利用它來進行內部運作。",
+		cant_load_profile = "<v>[#] <r>玩家 <b>%s</b> 看來不在線或是不存在。",
+		like_map = "你喜歡這地圖嗎?",
+		yes = "是",
+		no = "不是",
+		idk = "我不知道",
+		unknown = "不明物",
+		powers = "能力",
+		press = "<vp>按 %s",
+		click = "<vp>左鍵點擊",
+		ranking_pos = "排名 #%s",
+		completed_maps = "<p align='center'><BV><B>完成的地圖數: %s</B></p></BV>",
+		leaderboard = "排行榜",
+		position = "<V><p align=\"center\">位置",
+		username = "<V><p align=\"center\">用戶名",
+		community = "<V><p align=\"center\">社區",
+		completed = "<V><p align=\"center\">完成地圖數",
+		overall_lb = "主要排名",
+		weekly_lb = "每周排名",
+		new_lang = "<v>[#] <d>語言已被更換成 繁體中文",
+
+		-- Power names
+		balloon = "氣球",
+		masterBalloon = "進階氣球",
+		bubble = "泡泡",
+		fly = "飛行",
+		snowball = "雪球",
+		speed = "加速",
+		teleport = "傳送",
+		smallbox = "小箱子",
+		cloud = "白雲",
+		rip = "墓碑",
+		choco = "巧克力棒",
+		bigBox = "大箱子",
+		trampoline = "彈床",
+		toilet = "馬桶",
+		pig = "豬",
+		sink = "下沉",
+		bathtub = "浴缸",
+		campfire = "營火",
+		chair = "椅子",
+	}
+	translations.ch = translations.cn
+	--[[ End of file translations/parkour/cn.lua ]]--
+	--[[ File translations/parkour/en.lua ]]--
+	translations.en = {
+		name = "en",
+		fullname = "English",
+
+		-- Error messages
+		corrupt_map = "<r>Corrupt map. Loading another.",
+		corrupt_map_vanilla = "<r>[ERROR] <n>Can not get information of this map.",
+		corrupt_map_mouse_start = "<r>[ERROR] <n>This map needs to have a start position (mouse spawn point).",
+		corrupt_map_needing_chair = "<r>[ERROR] <n>The map needs to have the end chair.",
+		corrupt_map_missing_checkpoints = "<r>[ERROR] <n>The map needs to have at least one checkpoint (yellow nail).",
+		corrupt_data = "<r>Unfortunately, your data was corrupt and has been reset.",
+		min_players = "<r>To save your data, there must be at least 4 unique players in the room. <bl>[%s/%s]",
+		tribe_house = "<r>Data will not be saved in tribehouses.",
+		invalid_syntax = "<r>Invalid syntax.",
+		code_error = "<r>An error appeared: <bl>%s-%s-%s %s",
+		emergency_mode = "<r>Initiating emergency shutdown, no new players allowed. Please go to another #parkour room.",
+		leaderboard_not_loaded = "<r>The leaderboard has not been loaded yet. Wait a minute.",
+		max_power_keys = "<v>[#] <r>You can only have at most %s powers in the same key.",
+
+		-- Help window
+		help = "Help",
+		staff = "Staff",
+		rules = "Rules",
+		contribute = "Contribute",
+		changelog = "News",
+		help_help = "<p align = 'center'><font size = '14'>Welcome to <T>#parkour!</T></font></p>\n<font size = '12'><p align='center'><J>Your goal is to reach all the checkpoints until you complete the map.</J></p>\n\n<N>• Press <O>O</O>, type <O>!op</O> or click the <O>configuration button</O> to open the <T>options menu</T>.\n• Press <O>P</O> or click the <O>hand icon</O> at the top-right to open the <T>powers menu</T>.\n• Press <O>L</O> or type <O>!lb</O> to open the <T>leaderboard</T>.\n• Press the <O>M</O> or <O>Delete</O> key to <T>/mort</T>, you can toggle the keys in the <J>Options</J> menu.\n• To know more about our <O>staff</O> and the <O>rules of parkour</O>, click on the <T>Staff</T> and <T>Rules</T> tab respectively.\n• Click <a href='event:discord'><o>here</o></a> to get the discord invite link and <a href='event:map_submission'><o>here</o></a> to get the map submission topic link.\n• Use <o>up</o> and <o>down</o> arrow keys when you need to scroll.\n\n<p align = 'center'><font size = '13'><T>Contributions are now open! For further details, click on the <O>Contribute</O> tab!</T></font></p>",
+		help_staff = "<p align = 'center'><font size = '13'><r>DISCLAIMER: Parkour staff ARE NOT Transformice staff and DO NOT have any power in the game itself, only within the module.</r>\nParkour staff ensure that the module runs smoothly with minimal issues, and are always available to assist players whenever necessary.</font></p>\nYou can type <D>!staff</D> in the chat to see the staff list.\n\n<font color = '#E7342A'>Administrators:</font> They are responsible for maintaining the module itself by adding new updates and fixing bugs.\n\n<font color = '#D0A9F0'>Team Managers:</font> They oversee the Moderator and Mapper teams, making sure they are performing their jobs well. They are also responsible for recruiting new members to the staff team.\n\n<font color = '#FFAAAA'>Moderators:</font> They are responsible for enforcing the rules of the module and punishing individuals who do not follow them.\n\n<font color = '#25C059'>Mappers:</font> They are responsible for reviewing, adding, and removing maps within the module to ensure that you have an enjoyable gameplay.",
+		help_rules = "<font size = '13'><B><J>All rules in the Transformice Terms and Conditions also apply to #parkour</J></B></font>\n\nIf you find any player breaking these rules, whisper the parkour mods in-game. If no mods are online, then it is recommended to report it in the discord server.\nWhen reporting, please include the server, room name, and player name.\n• Ex: en-#parkour10 Blank#3495 trolling\nEvidence, such as screenshots, videos and gifs are helpful and appreciated, but not necessary.\n\n<font size = '11'>• No <font color = '#ef1111'>hacks, glitches or bugs</font> are to be used in #parkour rooms\n• <font color = '#ef1111'>VPN farming</font> will be considered an <B>exploit</B> and is not allowed. <p align = 'center'><font color = '#cc2222' size = '12'><B>\nAnyone caught breaking these rules will be immediately banned.</B></font></p>\n\n<font size = '12'>Transformice allows the concept of trolling. However, <font color='#cc2222'><B>we will not allow it in parkour.</B></font></font>\n\n<p align = 'center'><J>Trolling is when a player intentionally uses their powers or consumables to prevent other players from finishing the map.</j></p>\n• Revenge trolling is <B>not a valid reason</B> to troll someone and you will still be punished.\n• Forcing help onto players trying to solo the map and refusing to stop when asked is also considered trolling.\n• <J>If a player does not want help or prefers to solo a map, please try your best to help other players</J>. However if another player needs help in the same checkpoint as the solo player, you can help them [both].\n\nIf a player is caught trolling, they will be punished on a time basis. Note that repeated trolling will lead to longer and more severe punishments.",
+		help_contribute = "<font size='14'>\n<p align='center'>The parkour management team loves open source code because it <t>helps the community</t>. You can <o>view</o> and <o>modify</o> the source code on <o><u><a href='event:github'>GitHub</a></u></o>.\n\nMaintaining the module is <t>strictly voluntary</t>, so any help regarding <t>code</t>, <t>bug reports</t>, <t>suggestions</t> and <t>creating maps</t> is always <u>welcome and appreciated</u>.\nYou can <vp>report bugs</vp> and <vp>give suggestions</vp> on <o><u><a href='event:discord'>Discord</a></u></o> and/or <o><u><a href='event:github'>GitHub</a></u></o>.\nYou can <vp>submit your maps</vp> in our <o><u><a href='event:map_submission'>Forum Thread</a></u></o>.\n\nMaintaining parkour is not expensive, but it is not free either. We'd love if you could help us by <t>donating any amount</t> <o><u><a href='event:donate'>here</a></u></o>.\n<u>All donations will go towards improving the module.</u></p>",
+		help_changelog = "<font size='13'><p align='center'><o>Version 2.10.0 - 17/04/2021</o></p>\n\n<font size='11'>• <font size='13'><b><j>THREE</J></b> brand new Transformice titles that can only be unlocked by playing <font color='#1A7EC9'><b>#parkour</b></font>!</font>\n• Two new statuses added to the profile.\n• Minor text adjustments.",
+
+		-- Congratulation messages
+		reached_level = "<d>Congratulations! You've reached level <vp>%s</vp>. (<t>%ss</t>)",
+		finished = "<d><o>%s</o> finished the parkour in <vp>%s</vp> seconds, <fc>congratulations!",
+		unlocked_power = "<ce><d>%s</d> unlocked the <vp>%s</vp> power.",
+
+		-- Information messages
+		mod_apps = "<j>Parkour moderator applications are now open! Use this link: <rose>%s",
+		staff_power = "<p align='center'><font size='12'><r>Parkour staff <b>do not</b> have any power outside of #parkour rooms.",
+		donate = "<vp>Type <b>!donate</b> if you would like to donate for this module!",
+		paused_events = "<cep><b>[Warning!]</b> <n>The module has reached it's critical limit and is being paused.",
+		resumed_events = "<n2>The module has been resumed.",
+		welcome = "<n>Welcome to <t>#parkour</t>!",
+		module_update = "<r><b>[Warning!]</b> <n>The module will update in <d>%02d:%02d</d>.",
+		leaderboard_loaded = "<j>The leaderboard has been loaded. Press L to open it.",
+		kill_minutes = "<R>Your powers have been disabled for %s minutes.",
+		permbanned = "<r>You have been permanently banned from #parkour.",
+		tempbanned = "<r>You have been banned from #parkour for %s minutes.",
+		forum_topic = "<rose>For more information about the module visit this link: %s",
+		report = "<j>Want to report a parkour player? <t><b>/c Parkour#8558 .report Username#0000</b></t>",
+
+		-- Easter Eggs
+		easter_egg_0  = "<ch>Finally the countdown begins...",
+		easter_egg_1  = "<ch>Less than 24 hours remaining!",
+		easter_egg_2  = "<ch>Woah, you're quite early! Aren't you too excited?",
+		easter_egg_3  = "<ch>A surprise is waiting...",
+		easter_egg_4  = "<ch>Do you know what's about to happen...?",
+		easter_egg_5  = "<ch>The clock keeps ticking...",
+		easter_egg_6  = "<ch>The time is near!",
+		easter_egg_7  = "<ch>The party is about to begin...",
+		easter_egg_8  = "<ch>Check your clock, is it time yet?",
+		easter_egg_9  = "<ch>Be careful, time is passing...",
+		easter_egg_10 = "<ch>Just sit back and relax, it'll be tomorrow in no time!",
+		easter_egg_11 = "<ch>Let's go to bed early, it'll make the time go faster!",
+		easter_egg_12 = "<ch>Patience is a virtue",
+		easter_egg_13 = "<ch>https://youtu.be/9jK-NcRmVcw",
+		double_maps = "<bv>Double maps on Saturday (GMT+2) and all powers are available for parkour's birthday week!",
+		double_maps_start = "<rose>IT'S PARKOUR'S BIRTHDAY WEEK! Double maps and all powers have been activated. Thank you for all the support and for playing this module!",
+		double_maps_end = "<rose>Parkour's birthday week has ended. Thank you for all the support and for playing this module!",
+
+		-- Records
+		records_enabled = "<v>[#] <d>Records mode is enabled in this room. Stats won't count and powers aren't enabled!\nYou can find more information about records in <b>%s</b>",
+		records_admin = "<v>[#] <d>You're an administrator of this records room. You can use the commands <b>!map</b>, <b>!setcp</b>, <b>!pw</b> and <b>!time</b>.",
+		records_completed = "<v>[#] <d>You've completed the map! If you would like to re-do it, type <b>!redo</b>.",
+		records_submit = "<v>[#] <d>Wow! Looks like you had the fastest time in the room. If you would like to submit your record, type <b>!submit</b>.",
+		records_invalid_map = "<v>[#] <r>Looks like this map is not in parkour rotation... You can't submit a record for it!",
+		records_not_fastest = "<v>[#] <r>Looks like you're not the fastest player in the room...",
+		records_already_submitted = "<v>[#] <r>You already submitted your record for this map!",
+		records_submitted = "<v>[#] <d>Your record for the map <b>%s</b> has been submitted.",
+
+		-- Miscellaneous
+		afk_popup = "\n<p align='center'><font size='30'><bv><b>YOU'RE ON AFK MODE</b></bv>\nMOVE TO RESPAWN</font>\n\n<font size='30'><u><t>Reminders:</t></u></font>\n\n<font size='15'><r>Players with a red line over them don't want help!\nTrolling/blocking other players in parkour is NOT allowed!<d>\nJoin our <cep><a href='event:discord'>discord server</a></cep>!\nWant to contribute with code? See our <cep><a href='event:github'>github repository</a></cep>\nDo you have a good map to submit? Post it in our <cep><a href='event:map_submission'>map submission topic</a></cep>\nCheck our <cep><a href='event:forum'>official topic</a></cep> for more information!\nSupport us by <cep><a href='event:donate'>donating!</a></cep>",
+		options = "<p align='center'><font size='20'>Parkour Options</font></p>\n\nUse <b>QWERTY</b> keyboard (disable if <b>AZERTY</b>)\n\nUse <b>M</b> hotkey for <b>/mort</b> (disable for <b>DEL</b>)\n\nShow your power cooldowns\n\nShow powers button\n\nShow help button\n\nShow map completion announcements\n\nShow no help symbol",
+		cooldown = "<v>[#] <r>Wait a few seconds before doing that again.",
+		power_options = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><b>QWERTY</b> keyboard" ..
+						 "\n\n<b>Hide</b> map count" ..
+						 "\n\nUse <b>default key</b>"),
+		unlock_power = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Complete <v>%s</v> maps" ..
+						"<font size='5'>\n\n</font>to unlock" ..
+						"<font size='5'>\n\n</font><v>%s</v>"),
+		upgrade_power = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Complete <v>%s</v> maps" ..
+						"<font size='5'>\n\n</font>to upgrade to" ..
+						"<font size='5'>\n\n</font><v>%s</v>"),
+		unlock_power_rank = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Rank <v>%s</v>" ..
+						"<font size='5'>\n\n</font>to unlock" ..
+						"<font size='5'>\n\n</font><v>%s</v>"),
+		upgrade_power_rank = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Rank <v>%s</v>" ..
+						"<font size='5'>\n\n</font>to upgrade to" ..
+						"<font size='5'>\n\n</font><v>%s</v>"),
+		maps_info = ("<p align='center'><font size='13' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
+					 "<font size='5'>\n\n</font>Completed Maps"),
+		overall_info = ("<p align='center'><font size='13' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
+						"<font size='5'>\n\n</font>Overall Leaderboard"),
+		weekly_info = ("<p align='center'><font size='13' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
+					   "<font size='5'>\n\n</font>Weekly Leaderboard"),
+		badges = "<font size='14' face='Lucida Console,Liberation Mono,Courier New,Verdana'>Badges (%s): <a href='event:_help:badge'><j>[?]</j></a>",
+		private_maps = "<bl>This player's map count is private. <a href='event:_help:private_maps'><j>[?]</j></a></bl>\n",
+		profile = ("<font size='12' face='Lucida Console,Liberation Mono,Courier New,Verdana'>%s%s %s\n\n" ..
+					"Overall leaderboard position: <b><v>%s</v></b>\n\n" ..
+					"Weekly leaderboard position: <b><v>%s</v></b>\n\n%s"),
+		map_count = "Map count: <b><v>%s</v> / <a href='event:_help:yellow_maps'><j>%s</j></a> / <a href='event:_help:red_maps'><r>%s</r></a></b>",
+		title_count = ("<b><j>«!»</j></b> Finished maps: <b><a href='event:_help:map_count_title'><v>%s</v></a></b>\n\n" ..
+					"<b><j>«!»</j></b> Collected checkpoints: <b><a href='event:_help:checkpoint_count_title'><v>%s</v></a></b>"),
+		help_badge = "Badges are accomplishments a player can get. Click over them to see their description.",
+		help_private_maps = "This player doesn't like to share their map count publicly! You can hide them too in your profile.",
+		help_yellow_maps = "Maps in yellow are the maps completed this week.",
+		help_red_maps = "Maps in red are the maps completed in the past hour.",
+		help_map_count_title = "You can get <b>Transformice</b> titles by completing parkour maps!",
+		help_checkpoint_count_title = "You can get <b>Transformice</b> titles by collecting all checkpoints in parkour maps!",
+		help_badge_1 = "This player has been a parkour staff member in the past.",
+		help_badge_2 = "This player is or was in the page 1 of the overall leaderboard.",
+		help_badge_3 = "This player is or was in the page 2 of the overall leaderboard.",
+		help_badge_4 = "This player is or was in the page 3 of the overall leaderboard.",
+		help_badge_5 = "This player is or was in the page 4 of the overall leaderboard.",
+		help_badge_6 = "This player is or was in the page 5 of the overall leaderboard.",
+		help_badge_7 = "This player has been in the podium of the weekly leaderboard when it has reset.",
+		help_badge_8 = "This player has got a record of 30 maps per hour.",
+		help_badge_9 = "This player has got a record of 35 maps per hour.",
+		help_badge_10 = "This player has got a record of 40 maps per hour.",
+		help_badge_11 = "This player has got a record of 45 maps per hour.",
+		help_badge_12 = "This player has got a record of 50 maps per hour.",
+		help_badge_13 = "This player has got a record of 55 maps per hour.",
+		help_badge_14 = "This player has verified their discord account in the official parkour server (type <b>!discord</b>).",
+		help_badge_15 = "This player has got the fastest time in 1 map.",
+		help_badge_16 = "This player has got the fastest time in 5 maps.",
+		help_badge_17 = "This player has got the fastest time in 10 maps.",
+		help_badge_18 = "This player has got the fastest time in 15 maps.",
+		help_badge_19 = "This player has got the fastest time in 20 maps.",
+		help_badge_20 = "This player has got the fastest time in 25 maps.",
+		help_badge_21 = "This player has got the fastest time in 30 maps.",
+		help_badge_22 = "This player has got the fastest time in 35 maps.",
+		help_badge_23 = "This player has got the fastest time in 40 maps.",
+		make_public = "make public",
+		make_private = "make private",
+		moderators = "Moderators",
+		mappers = "Mappers",
+		managers = "Managers",
+		administrators = "Administrators",
+		close = "Close",
+		cant_load_bot_profile = "<v>[#] <r>You can't see this bot's profile since #parkour uses it internally to work properly.",
+		cant_load_profile = "<v>[#] <r>The player <b>%s</b> seems to be offline or does not exist.",
+		like_map = "Do you like this map?",
+		yes = "Yes",
+		no = "No",
+		idk = "I don't know",
+		unknown = "Unknown",
+		powers = "Powers",
+		press = "<vp>Press %s",
+		click = "<vp>Left click",
+		ranking_pos = "Rank #%s",
+		completed_maps = "<p align='center'><BV><B>Completed maps: %s</B></p></BV>",
+		leaderboard = "Leaderboard",
+		position = "<V><p align=\"center\">Position",
+		username = "<V><p align=\"center\">Username",
+		community = "<V><p align=\"center\">Community",
+		completed = "<V><p align=\"center\">Completed maps",
+		overall_lb = "Overall",
+		weekly_lb = "Weekly",
+		new_lang = "<v>[#] <d>Language set to English",
+
+		-- Power names
+		balloon = "Balloon",
+		masterBalloon = "Master Ballon",
+		bubble = "Bubble",
+		fly = "Fly",
+		snowball = "Snowball",
+		speed = "Speed",
+		teleport = "Teleport",
+		smallbox = "Small box",
+		cloud = "Cloud",
+		rip = "Tombstone",
+		choco = "Chocoplank",
+		bigBox = "Big box",
+		trampoline = "Trampoline",
+		toilet = "Toilet",
+		pig = "Piglet",
+		sink = "Sink",
+		bathtub = "Bathtub",
+		campfire = "Campfire",
+		chair = "Chair",
+	}
+	--[[ End of file translations/parkour/en.lua ]]--
+	--[[ File translations/parkour/br.lua ]]--
+	translations.br = {
+		name = "br",
+		fullname = "Português",
+
+		-- Error messages
+		corrupt_map = "<r>Mapa corrompido. Carregando outro.",
+		corrupt_map_vanilla = "<r>[ERROR] <n>Não foi possível obter informações deste mapa.",
+		corrupt_map_mouse_start = "<r>[ERROR] <n>O mapa requer um ponto de partida (spawn).",
+		corrupt_map_needing_chair = "<r>[ERROR] <n>O mapa requer a poltrona final.",
+		corrupt_map_missing_checkpoints = "<r>[ERROR] <n>O mapa requer ao menos um checkpoint (prego amarelo).",
+		corrupt_data = "<r>Infelizmente seus dados corromperam e foram reiniciados.",
+		min_players = "<r>Para que dados sejam salvos, ao menos 4 jogadores únicos devem estar na sala. <bl>[%s/%s]",
+		tribe_house = "<r>Para que dados sejam salvos, você precisa jogar fora de um cafofo de tribo.",
+		invalid_syntax = "<r>Sintaxe inválida.",
+		code_error = "<r>Um erro aconteceu: <bl>%s-%s-%s %s",
+		emergency_mode = "<r>Começando desativação de emergência, novos jogadores não serão mais permitidos. Por favor, vá para outra sala #parkour.",
+		leaderboard_not_loaded = "<r>O ranking ainda não foi carregado. Aguarde um minuto.",
+		max_power_keys = "<v>[#] <r>Você pode ter no máximo %s poderes na mesma tecla.",
+
+		-- Help window
+		help = "Ajuda",
+		staff = "Staff",
+		rules = "Regras",
+		contribute = "Contribuir",
+		changelog = "Novidades",
+		help_help = "<p align = 'center'><font size = '14'>Bem-vindo ao <T>#parkour!</T></font></p>\n<font size = '12'><p align='center'><J>Seu objetivo é chegar em todos os checkpoints até que você complete o mapa.</J></p>\n\n<N>• Aperte <O>O</O>, digite <O>!op</O> ou clique no <O>botão de configuração</O> para abrir o <T>menu de opções</T>.\n• Aperte <O>P</O> ou clique no <O>ícone de mão</O> no parte superior direita para abrir o <T>menu de poderes</T>.\n• Aperte <O>L</O> ou digite <O>!lb</O> parar abrir o <T>ranking</T>.\n• Aperte <O>M</O> ou a tecla <O>Delete</O> para <T>/mort</T>, você pode alterar as teclas no moenu de <J>Opções</J>.\n• Para saber mais sobre nossa <O>staff</O> e as <O>regras do parkour</O>, clique nas abas <T>Staff</T> e <T>Regras</T>, respectivamente.\n• Clique <a href='event:discord'><o>aqui</o></a> para obter um link de convide para o nosso servidor no Discord e <a href='event:map_submission'><o>aqui</o></a> para obter o link do tópico de avaliação de mapas.\n• Use as setas <o>para cima</o> ou <o>para baixo</o> quando você precisar rolar a página.\n\n<p align = 'center'><font size = '13'><T>Contribuições agora estão disponíveis! Para mais detalhes, clique na aba <O>Contribuir</O>!</T></font></p>",
+		help_staff = "<p align = 'center'><font size = '13'><r>AVISO: A staff do Parkour não faz parte da staff do Transformice e não tem nenhum poder no jogo em si, apenas no módulo.</r>\nStaff do Parkour assegura que o módulo rode com problemas mínimos, e estão sempre disponíveis para dar assistência aos jogadores quando necessário.</font></p>\nVocê pode digitar <D>!staff</D> no chat para ver a lista de staff.\n\n<font color = '#E7342A'>Administradores:</font> São responsáveis por manter o módulo propriamente dito, atualizando-o e corrigindo bugs.\n\n<font color = '#D0A9F0'>Gerenciadores das Equipes:</font> Observam as equipes de Moderação e de Mapas, assegurando que todos estão fazendo um bom trabalho. Também são responsáveis por recrutar novos membros para a staff.\n\n<font color = '#FFAAAA'>Moderadores:</font> São responsáveis por aplicar as regras no módulo e punir aqueles que não as seguem.\n\n<font color = '#25C059'>Mappers:</font> São responsáveis por avaliar, adicionar e remover mapas do módulo para assegurar que você tenha uma jogatina divertida.",
+		help_rules = "<font size = '13'><B><J>Todas as regras nos Termos e Condições de Uso do Transformice também se aplicam no #parkour</J></B></font>\n\nSe você encontrar algum jogador quebrando-as, cochiche com um moderador do #parkour no jogo. Se os moderadores não estiverem online, recomendamos que reporte em nosso servidor no Discord.\nAo reportar, por favor inclua a comunidade, o nome da sala e o nome do jogador.\n• Ex: en-#parkour10 Blank#3495 trolling\nEvidências, como prints, vídeos e gifs são úteis e apreciados, mas não necessários.\n\n<font size = '11'>• Uso de <font color = '#ef1111'>hacks, glitches ou bugs</font> são proibidos em salas #parkour\n• <font color = '#ef1111'>Farm VPN</font> será considerado um <B>abuso</B> e não é permitido. <p align = 'center'><font color = '#cc2222' size = '12'><B>\nQualquer um pego quebrando as regras será banido imediatamente.</B></font></p>\n\n<font size = '12'>Transformice permite trollar. No entanto, <font color='#cc2222'><B>não permitiremos isso no parkour.</B></font></font>\n\n<p align = 'center'><J>Trollar é quando um jogador intencionalmente usa seus poderes ou consumíveis para fazer com que outros jogadores não consigam terminar o mapa.</j></p>\n• Trollar por vingança <B>não é um motivo válido</B> e você ainda será punido.\n• Insistir em ajudar jogadores que estão tentando terminar o mapa sozinhos e se recusando a parar quando pedido também será considerado trollar.\n• <J>Se um jogador não quer ajuda e prefere completar o mapa sozinho, dê seu melhor para ajudar os outros jogadores</J>. No entanto, se outro jogador que precisa de ajuda estiver no mesmo checkpoint daquele que quer completar sozinho, você pode ajudar ambos sem receber punição.\n\nSe um jogador é pego trollando, será punido em uma questão de tempo. Note que trollar repetidamente irá fazer com que você receba punições gradativamente mais longas e/ou severas.",
+		help_contribute = "<font size='14'>\n<p align='center'>A equipe do parkour adora ter um código aberto, pois isso <t>ajuda a comunidade</t>. Você pode <o>ver</o> ou <o>contribuir</o> com o código no <o><u><a href='event:github'>GitHub</a></u></o>.\n\nManter o módulo é parte de um trabalho <t>voluntário</t>, então qualquer contribuição é <u>bem vinda</u>, seja com a <t>programação</t>, <t>reporte de erros</t>, <t>sugestões</t> e <t>criação de mapas</t>.\nVocê pode <vp>reportar erros</vp> ou <vp>dar sugestões</vp> no nosso <o><u><a href='event:discord'>Discord</a></u></o> e/ou no <o><u><a href='event:github'>GitHub</a></u></o>.\nVocê pode <vp>enviar seus mapas</vp> no nosso <o><u><a href='event:map_submission'>Tópico no Fórum</a></u></o>.\n\nManter o jogo não é caro, mas também não é grátis. Nós adoraríamos se você pudesse incentivar o desenvolvimento do jogo <t>doando qualquer valor</t> <o><u><a href='event:donate'>aqui</a></u></o>.\n<u>Todos os fundos arrecadados serão direcionados para o desenvolvimento do módulo.</u></p>",
+		help_changelog = "<font size='13'><p align='center'><o>Versão 2.10.0 - 17/04/2021</o></p>\n\n<font size='11'>• <font size='13'><b><j>TRÊS</J></b> novos títulos no Transformice que só podem ser desbloqueados jogando <font color='#1A7EC9'><b>#parkour</b></font>!</font>\n• Duas novas estatísticas adicionadas no perfil.\n• Ajustes menores em textos.",
+
+		-- Congratulation messages
+		reached_level = "<d>Parabéns! Você atingiu o nível <vp>%s</vp>. (<t>%ss</t>)",
+		finished = "<d><o>%s</o> terminou o parkour em <vp>%s</vp> segundos, <fc>parabéns!",
+		unlocked_power = "<ce><d>%s</d> desbloqueou o poder <vp>%s</vp>.",
+
+		-- Information messages
+		mod_apps = "<j>As inscrições para moderador do parkour estão abertas! Use esse link: <rose>%s",
+		staff_power = "<r>A Staff do Parkour <b>não</b> tem nenhum poder fora das salas #parkour.",
+		donate = "<vp>Digite <b>!donate</b> se você gostaria de doar para este módulo!",
+		paused_events = "<cep><b>[Atenção!]</b> <n>O módulo está atingindo um estado crítico e está sendo pausado.",
+		resumed_events = "<n2>O módulo está se normalizando.",
+		welcome = "<n>Bem-vindo(a) ao <t>#parkour</t>!",
+		module_update = "<r><b>[Atenção!]</b> <n>O módulo irá atualizar em <d>%02d:%02d</d>.",
+		leaderboard_loaded = "<j>O ranking foi carregado. Aperte L para abri-lo.",
+		kill_minutes = "<R>Seus poderes foram desativados por %s minutos.",
+		permbanned = "<r>Você foi banido permanentemente do #parkour.",
+		tempbanned = "<r>Você foi banido do #parkour por %s minutos.",
+		forum_topic = "<rose>Para mais informações sobre o módulo, acesse o link: %s",
+		report = "<j>Quer reportar um jogador? <t><b>/c Parkour#8558 .report NomeJogador#0000</b></t>",
+
+		-- Easter Eggs
+		easter_egg_0  = "<ch>E a contagem regressiva começa...",
+		easter_egg_1  = "<ch>Menos de 24 horas restantes!",
+		easter_egg_2  = "<ch>Eita, você está muito adiantado! Está muito ansioso?",
+		easter_egg_3  = "<ch>Uma surpresa está no forno...",
+		easter_egg_4  = "<ch>Você sabe o que está prestes a acontecer...?",
+		easter_egg_5  = "<ch>O tempo está passando...",
+		easter_egg_6  = "<ch>A surpresa está próxima!",
+		easter_egg_7  = "<ch>A festa está prestes a começar...",
+		easter_egg_8  = "<ch>Que horas são? Já deu a hora?",
+		easter_egg_9  = "<ch>Atente-se, o tempo está passando...",
+		easter_egg_10 = "<ch>Apenas sente e relaxe, será amanhã sem horário definido!",
+		easter_egg_11 = "<ch>Vamos para a cama mais cedo, o tempo vai passar mais rápido!",
+		easter_egg_12 = "<ch>Paciência é uma virtude",
+		easter_egg_13 = "<ch>https://youtu.be/9jK-NcRmVcw",
+		double_maps = "<bv>Você ganhará duas vezes mais vitórias no Sábado (GMT+2) e todos os poderes estarão disponíveis na semana de aniversário do Parkour!",
+		double_maps_start = "<rose>É A SEMANA DE ANIVERSÁRIO DO PARKOUR! Você ganhará duas vezes mais vitórias e todos os poderes foram ativados. Muito obrigado por jogar com a gente!",
+		double_maps_end = "<rose>A semana de aniversário do Parkour terminou. Muito obrigado por jogar com a gente!",
+
+		-- Records
+		records_enabled = "<v>[#] <d>Modo Records está ativado nesta sala. Dados não serão contados e poderes não estão ativados!\nVocê poderá encontrar mais informações sobre records em <b>%s</b>",
+		records_admin = "<v>[#] <d>Você é um administrador desta sala de records. Você pode usar os comandos <b>!map</b>, <b>!setcp</b>, <b>!pw</b> e <b>!time</b>.",
+		records_completed = "<v>[#] <d>Você completou o mapa! Se você quiser jogar nele novamente, digite <b>!redo</b>.",
+		records_submit = "<v>[#] <d>Wow! Parece que você teve o melhor tempo nesta sala. Se você quiser enviar o record, digite <b>!submit</b>.",
+		records_invalid_map = "<v>[#] <r>Parece que este mapa não está na rotação de mapas do parkour... Você não pode enviar um recorde para ele",
+		records_not_fastest = "<v>[#] <r>Parece que você não é o jogador mais rápido na sala...",
+		records_already_submitted = "<v>[#] <r>Você já enviou seu recorde para este mapa!",
+		records_submitted = "<v>[#] <d>Seu recorde para o mapa <b>%s</b> foi enviado.",
+
+		-- Miscellaneous
+		afk_popup = "\n<p align='center'><font size='30'><bv><b>VOCê ESTÁ NO MODO AFK</b></bv>\nMOVA-SE PARA RENASCER</font>\n\n<font size='30'><u><t>Lembretes:</t></u></font>\n\n<font size='15'><r>Jogadores com uma linha vermelha em cima deles não querem ajuda!\nTrollar/bloquear outros jogadores no parkour NÃO é permitido!<d>\nEntre em nosso <cep><a href='event:discord'>servidor no Discord</a></cep>!\nQuer contribuir com código? Veja nosso <cep><a href='event:github'>repositório no Github</a></cep>\nVocê tem um mapa bom pra enviar? Mande-o em nosso <cep><a href='event:map_submission'>tópico de submissão de mapas</a></cep>\nCheque nosso <cep><a href='event:forum'>tópico oficial no fórum</a></cep> para mais informações!\nNos apoie com <cep><a href='event:donate'>doações!</a></cep>",
+		options = "<p align='center'><font size='20'>Opções do Parkour</font></p>\n\nUsar o teclado <b>QWERTY</b> (desativar caso seja <b>AZERTY</b>)\n\nUsar a tecla <b>M</b> como <b>/mort</b> (desativar caso seja <b>DEL</b>)\n\nMostrar o delay do seu poder\n\nMostrar o botão de poderes\n\nMostrar o botão de ajuda\n\nMostrar mensagens de mapa completado\n\nMostrar símbolo de não ajudar",
+		cooldown = "<v>[#] <r>Aguarde alguns segundos antes de fazer isso novamente.",
+		power_options = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'>Teclado <b>QWERTY</b>" ..
+						 "\n\n<b>Esconder</b> contagem de mapas" ..
+						 "\n\nUsar <b>tecla padrão</b>"),
+		unlock_power = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Complete <v>%s</v> mapas" ..
+						"<font size='5'>\n\n</font>para desbloquear" ..
+						"<font size='5'>\n\n</font><v>%s</v>"),
+		upgrade_power = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Complete <v>%s</v> mapas" ..
+						"<font size='5'>\n\n</font>para evoluir para" ..
+						"<font size='5'>\n\n</font><v>%s</v>"),
+		unlock_power_rank = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Seja top <v>%s</v>" ..
+						"<font size='5'>\n\n</font>para desbloquear" ..
+						"<font size='5'>\n\n</font><v>%s</v>"),
+		upgrade_power_rank = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Seja top <v>%s</v>" ..
+						"<font size='5'>\n\n</font>para evoluir para" ..
+						"<font size='5'>\n\n</font><v>%s</v>"),
+		maps_info = ("<p align='center'><font size='13' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
+					 "<font size='5'>\n\n</font>Mapas completados"),
+		overall_info = ("<p align='center'><font size='13' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
+						"<font size='5'>\n\n</font>Ranking Geral"),
+		weekly_info = ("<p align='center'><font size='13' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
+					   "<font size='5'>\n\n</font>Ranking Semanal"),
+		badges = "<font size='14' face='Lucida Console,Liberation Mono,Courier New,Verdana'>Medalhas (%s): <a href='event:_help:badge'><j>[?]</j></a>",
+		private_maps = "<bl>A contagem de mapas deste jogador é privado. <a href='event:_help:private_maps'><j>[?]</j></a></bl>\n",
+		profile = ("<font size='12' face='Lucida Console,Liberation Mono,Courier New,Verdana'>%s%s %s\n\n" ..
+					"Posição no Ranking geral: <b><v>%s</v></b>\n\n" ..
+					"Posição no Ranking semanal: <b><v>%s</v></b>\n\n%s"),
+		map_count = "Contagem de mapas: <b><v>%s</v> / <a href='event:_help:yellow_maps'><j>%s</j></a> / <a href='event:_help:red_maps'><r>%s</r></a></b>",
+		title_count = ("<b><j>«!»</j></b> Mapas completados: <b><a href='event:_help:map_count_title'><v>%s</v></a></b>\n\n" ..
+			"<b><j>«!»</j></b> Checkpoints coletados: <b><a href='event:_help:checkpoint_count_title'><v>%s</v></a></b>"),
+		help_badge = "Medalhas são objetivos que um jogador pode conseguir. Clique nelas para ler suas descrições.",
+		help_private_maps = "Este jogador não gosta de divulgar sua contagem de mapas publicamente! Você também pode escondê-la em seu perfil.",
+		help_yellow_maps = "Mapas em amarelo são os mapas completados nesta semana.",
+		help_red_maps = "Mapas em vermelho são os mapas completados na última hora.",
+		help_map_count_title = "Você pode conseguir títulos no <b>Transformice</b> ao completar mapas parkour!",
+		help_checkpoint_count_title = "Você pode conseguir títulos no <b>Transformice</b> ao coletar todos os checkpoints em mapas parkour!",
+		help_badge_1 = "Este jogador já foi um membro da staff do #parkour no passado.",
+		help_badge_2 = "Este jogador está ou já esteve na página 1 do ranking global.",
+		help_badge_3 = "Este jogador está ou já esteve na página 2 do ranking global.",
+		help_badge_4 = "Este jogador está ou já esteve na página 3 do ranking global.",
+		help_badge_5 = "Este jogador está ou já esteve na página 4 do ranking global.",
+		help_badge_6 = "Este jogador está ou já esteve na página 5 do ranking global.",
+		help_badge_7 = "Este jogador esteve no pódio no fim de um ranking semanal.",
+		help_badge_8 = "Este jogador bateu um recorde de 30 mapas por hora.",
+		help_badge_9 = "Este jogador bateu um recorde de 35 mapas por hora.",
+		help_badge_10 = "Este jogador bateu um recorde de 40 mapas por hora.",
+		help_badge_11 = "Este jogador bateu um recorde de 45 mapas por hora.",
+		help_badge_12 = "Este jogador bateu um recorde de 50 mapas por hora.",
+		help_badge_13 = "Este jogador bateu um recorde de 55 mapas por hora.",
+		help_badge_14 = "Este jogador verificou sua conta no servidor oficial do Parkour no Discord (digite <b>!discord</b>).",
+		help_badge_15 = "Este jogador teve o tempo mais rápido em 1 mapa.",
+		help_badge_16 = "Este jogador teve o tempo mais rápido em 5 mapas.",
+		help_badge_17 = "Este jogador teve o tempo mais rápido em 10 mapas.",
+		help_badge_18 = "Este jogador teve o tempo mais rápido em 15 mapas.",
+		help_badge_19 = "Este jogador teve o tempo mais rápido em 20 mapas.",
+		help_badge_20 = "Este jogador teve o tempo mais rápido em 25 mapas.",
+		help_badge_21 = "Este jogador teve o tempo mais rápido em 30 mapas.",
+		help_badge_22 = "Este jogador teve o tempo mais rápido em 35 mapas.",
+		help_badge_23 = "Este jogador teve o tempo mais rápido em 40 mapas.",
+		make_public = "tornar público",
+		make_private = "tornar privado",
+		moderators = "Moderadores",
+		mappers = "Mappers",
+		managers = "Gerentes",
+		administrators = "Administradores",
+		close = "Fechar",
+		cant_load_bot_profile = "<v>[#] <r>Você não pode ver o perfil deste bot já que o #parkour utiliza-o internamente para funcionar devidamente.",
+		cant_load_profile = "<v>[#] <r>O jogador <b>%s</b> parece estar offline ou não existe.",
+		like_map = "Você gosta deste mapa?",
+		yes = "Sim",
+		no = "Não",
+		idk = "Não sei",
+		unknown = "Desconhecido",
+		powers = "Poderes",
+		press = "<vp>Aperte %s",
+		click = "<vp>Use click",
+		ranking_pos = "Rank #%s",
+		completed_maps = "<p align='center'><BV><B>Mapas completados: %s</B></p></BV>",
+		leaderboard = "Ranking",
+		position = "<V><p align=\"center\">Posição",
+		username = "<V><p align=\"center\">Nome",
+		community = "<V><p align=\"center\">Comunidade",
+		completed = "<V><p align=\"center\">Mapas completados",
+		overall_lb = "Geral",
+		weekly_lb = "Semanal",
+		new_lang = "<v>[#] <d>Idioma definido para Português",
+
+		-- Power names
+		balloon = "Balão",
+		masterBalloon = "Balão Mestre",
+		bubble = "Bolha",
+		fly = "Voar",
+		snowball = "Bola de Neve",
+		speed = "Velocidade",
+		teleport = "Teleporte",
+		smallbox = "Caixa Pequena",
+		cloud = "Nuvem",
+		rip = "Lápide",
+		choco = "Choco-tábua",
+		bigBox = "Caixa grande",
+		trampoline = "Trampolim",
+		toilet = "Vaso Sanitário",
+		pig = "Leitão",
+		sink = "Pia",
+		bathtub = "Banheira",
+		campfire = "Fogueira",
+		chair = "Cadeira",
+	}
+	translations.pt = translations.br
+	--[[ End of file translations/parkour/br.lua ]]--
+	--[[ File translations/parkour/he.lua ]]--
+	translations.he = {
+		name = "he",
+		fullname = "עברית",
+
+		-- Error messages
+		corrupt_map = "<r>מפה משובשת, טוען אחרת.",
+		corrupt_map_vanilla = "<r>[שגיאה] <n>לא ניתן לקבל מידע אודות מפה זו.",
+		corrupt_map_mouse_start = "<r>[שגיאה] <n>דרוש מקום התחלה במפה זו (נקודת התחלה של העכבר).",
+		corrupt_map_needing_chair = "<r>[שגיאה] <n>מפה זו צריכה ספה בנקודה הסופית.",
+		corrupt_map_missing_checkpoints = "<r>[שגיאה] <n>נדרשת לפחות נקודת שמירה אחת במפה זו (נקודה צהובה).",
+		corrupt_data = "<r>למרבה הצער, נתוניך נפגמו ואופסו.",
+		min_players = "<r>על מת שנתוניך ישמרו, חייבים להיות לפחות ארבעה שחקנים שונים בחדר זה. <bl>[%s/%s]",
+		tribe_house = "<r>נתונים לא ישמרו בבתי שבט.",
+		invalid_syntax = "<r>syntax שגוי.",
+		code_error = "<r>שגיאה התגלתה: <bl>%s-%s-%s %s",
+		emergency_mode = "<r>מתחיל כיבוי חירום, אין כניסה לשחקנים חדשים. אנא לך לחדר #parkour אחר.",
+		leaderboard_not_loaded = "<r>הלוח תוצאות עדיין לא נטען, המתן דקה.",
+		max_power_keys = "<v>[#] <r>אתם יכולים שיהיו לכם עד %s כוחות על אותו מקש.",
+
+		-- Help window
+		help = "עזרה",
+		staff = "צוות",
+		rules = "חוקים",
+		contribute = "תרומה",
+		changelog = "חדש",
+		help_help = "<p align = 'center'><font size = '14'>ברוך הבא ל-<T>#parkour!</T></font></p>\n<font size = '12'><p align='center'><J>מטרתך להשיג את כל נקודות השמירה עד שאתה מסיים את המפה.</J></p>\n\n<N>• לחץ <O>ם</O>, כתוב <O>!op</O> או לחץ על <O>גלגל השיניים</O> בכדי לפתוח את <T>ההגדרות</T>.\n• לחץ <O>פ</O> או לחץ על <O>כפתור האגרוף</O> בצד ימין למעלה על מנת לפתוח את <T>תפריט הכוחות</T>.\n• לחץ <O>ך</O> או כתוב <O>!lb</O> בכדי לפתוח את <T>לוח התוצאות</T>.\n• לחץ על <O>צ</O> או כפתור ה-<O>Delete</O> כתחליף ל-<T>/mort</T>, אתה יכול להחליף בין המקשים <J>בהגדרות</J>.\n• על מנת לדעת עוד על <O>הצוות</O> שלנו ועל <O>החוקים של פארקור</O>, לחץ על הכרטיסיות <T>צוות</T> ו<T>חוקים</T> לפי הסדר.\n• לחץ <a href='event:discord'><o>כאן</o></a> בכדי לקבל הזמנה לשרת הדיסקורד ו<a href='event:map_submission'><o>כאן</o></a> בכדי לקבל קישור לנושא הגשת המפות.\n• לחץ על חיצי ה<o>למעלה</o> וה<o>למטה</o> כאשר אתה צריך לגלול.\n\n<p align = 'center'><font size = '13'><T>ניתן כעת לתרום! לפרטים נוספים לחצו על הכרטיסייה <O>תרומה</O> tab!</T></font></p>",
+		help_staff = "<p align = 'center'><font size = '13'><r>הערה: צוות הפארקור אינו צוות המשחק ואין לו שום כוח במשחק עצמו, אלא רק במודול</r>\nצוות הפארקור מוודא כי המודול רץ בצורה חלקה עם עניינים מינימליים והם תמיד זמינים לעזור לשחקנים מתי שצריך.</font></p>\nאתה יכול לכתוב <D>!staff</D> בצ'אט כדי לראות את רשימת הצוות.\n\n<font color = '#E7342A'>אדמינים:</font> הם אחראים לשמור על המודול עי הוספת עדכונים ותיקוני באגים.\n\n<font color = '#D0A9F0'>מנהלי צוות:</font> הם מפקחים על צוותי הניהול והמפות, מוודאים כי הם מבצעים את עבודתם כשורה. בנוסף, הם האחראים על גיוס חברים חדשים לצוות.\n\n<font color = '#FFAAAA'>מנהלים:</font> הם האחראים לאכוף את חוקי המודול והענשת משתמשים אשר לא שומרים עליהם.\n\n<font color = '#25C059'>צוות מפות:</font> הם האחראים על סקירה, הוספה והסרה של מפות במודול הפארקור בכדי להבטיח שיהיה לכם משחק מהנה.",
+		help_rules = "<font size = '13'><B><J>כל החוקים, התנאים וההגבלות של הטראנספורמייס חלים גם על #parkour</J></B></font>\n\nאם אתם מוצאים שחקן אשר עובר על חוקים אלה, שלחו לחישה למנהלי פארקור במשחק. אם אין מנהלים מחוברים, מומלץ לדווח על כך בשרת הדיסקורד.\nכאשר מדווחים, בבקשה כללו את השרת, שם החדר, ושם המשתמש של השחקן.\n• דוגמא: en-#parkour10 Blank#3495 trolling\nהוכחות כגון צילומי מסך, וידאו או גיפס הם יעילים ומוערכים, אך לא חייב.\n\n<font size = '11'>• אין להשתמש ב<font color = '#ef1111'>האקים, גליצ'ים או באגים</font> בחדרי פארקור\n• <font color = '#ef1111'>פארם VPN </font> ייחשב כ<B>ניצול</B> והדבר אסור. <p align = 'center'><font color = '#cc2222' size = '12'><B>\nכל אחד שיתפס עובר על חוקים אלה יורחק באופן מיידי.</B></font></p>\n\n<font size = '12'>טראנספורמייס מרשה לעשות טרולים. עם זאת, <font color='#cc2222'><B>אנו לא נאפשר זאת בפארקור.</B></font></font>\n\n<p align = 'center'><J>טרול זה כאשר שחקן משתמש בכוחותיו או במוצרי זריקה בכוונה תחילה כדי למנוע משחקנים אחרים לסיים את המפה.</j></p>\n• טרול כנקמה הוא <B>אינו סיבה מוצדקת</B> להטריל מישהו ואתם עדיין תענשו.\n• כפיית עזרה על שחקנים שמנסים להשלים לבדם את המפה וסירוב להפסיק כאשר התבקשת לכך ייחשב כטרול.\n• <J>אם שחקן אינו מעוניין בעזרה או מעוניין להשלים לבדו את המפה, אנא נסו ככל יכולתכם לעזור לשחקנים אחרים</J>. עם זאת, אם שחקן אחר צריך עזרה באותה נקודה כמו השחקן השני שרוצה להשלים לבד, אתה יכול לעזור לשניהם.\n\nאם שחקן יתפס מטריל, הוא יענש על בסיס זמן. חשוב לציין כי ביצוע טרול שוב ושוב יוביל לעונשים ארוכים יותר וחמורים יותר.",
+		help_contribute = "<font size='14'>\n<p align='center'>צוות הניהול של פארקור אוהב לפתוח את קוד המקור מכיוון שזה <t>עוזר לקהילה</t>. אתה יכול <o>לראות</o> ו<o>לערוך</o> את קוד המקור ב-<o><u><a href='event:github'>GitHub</a></u></o>.\n\nשמירה על המודול היא <t>התנדבותית לחלוטין</t>. לכן, כל עזרה ב<t>קודים</t>, <t>דיווח על באגים</t>, <t>הצעות</t> ו<t>יצירת מפות</t> תמיד <u>מתקבלת בברכה ומוערכת</u>.\nאתה יכול <vp>לדווח אודות באגים</vp> ו<vp>להציע הצעות</vp> ב<o><u><a href='event:discord'>דיסקורד</a></u></o> ו/או ב-<o><u><a href='event:github'>GitHub</a></u></o>.\nאתה יכול <vp>להגיש את מפותיך</vp> ב<o><u><a href='event:map_submission'>נושא הפורום</a></u></o> שלנו.\n\nאחזקת פארקור איננה יקרה, אך גם איננה חינמית. אנו נשמח אם תוכלו לעזור לנו עי <t>תרומה בכל סכום</t> <o><u><a href='event:donate'>כאן</a></u></o>.\n<u>כל התרומות הולכות היישר לשיפור המודול.</u></p>",
+		help_changelog = "<font size='13'><p align='center'><o>Version 2.10.0 - 17/04/2021</o></p>\n\n<font size='11'>• <font size='13'><b><j>THREE</J></b> brand new Transformice titles that can only be unlocked by playing <font color='#1A7EC9'><b>#parkour</b></font>!</font>\n• Two new statuses added to the profile.\n• Minor text adjustments.",
+
+		-- Congratulation messages
+		reached_level = "<d>ברכות! עלית לרמה <vp>%s</vp>. (<t>%ss</t>)",
+		finished = "<d><o>%s</o> סיים את הפארקור תוך <vp>%s</vp> שניות, <fc>ברכות!",
+		unlocked_power = "<ce><d>%s</d> השיג את הכח <vp>%s</vp>.",
+
+		-- Information messages
+		mod_apps = "<j>הגשות מועמדות להיות מנהל/ת פארקור פתוחות כעת! השתמש בקישור זה: <rose>%s",
+		staff_power = "<r>לצוות פארקור <b>אין</b> שום כוחות מחוץ לחדרי פארקור.",
+		donate = "<vp>הקלד <b>!donate</b> אם תרצה לתרום עבור מודול זה!",
+		paused_events = "<cep><b>[אזהרה!]</b> <n>המשחק הגיע למגבלה קריטית ונעצר כעת.",
+		resumed_events = "<n2>המשחק נמשך.",
+		welcome = "<n>ברוכים הבאים ל<t>#parkour</t>!",
+		module_update = "<r><b>[אזהרה!]</b> <n>המשחק יעדוכן בעוד <d>%02d:%02d</d>.",
+		leaderboard_loaded = "<j>לוח התוצאות נטען. לחץ L כדי לפתוח אותו.",
+		kill_minutes = "<R>כוחותיך הושבתו ל-%s דקות.",
+		permbanned = "<r>הורחקת לצמיתות מ-#parkour.",
+		tempbanned = "<r>הורחקת מ-#parkour למשך %s דקות.",
+		forum_topic = "<rose>למידע נוסף אודות פארקור כנסו לקישור: %s",
+		report = "<j>רוצים לדווח על שחקן? <t><b>/c Parkour#8558 .report Username#0000</b></t>",
+
+		-- Easter Eggs
+		easter_egg_0  = "<ch>הספירה מתחילה...",
+		easter_egg_1  = "<ch>פחות מ24 שעות נותרו!",
+		easter_egg_2  = "<ch>וואו, הגעת מוקדם! גם אתה מתרגש?",
+		easter_egg_3  = "<ch>הפתעה מחכה...",
+		easter_egg_4  = "<ch>אתה יודע מה הולך לקרות...?",
+		easter_egg_5  = "<ch>השעון ממשיך לתקתק...",
+		easter_egg_6  = "<ch>ההפתעה קרבה!",
+		easter_egg_7  = "<ch>המסיבה עוד רגע מתחילה...",
+		easter_egg_8  = "<ch>תסתכל בשעות, כבר הגיע הזמן?",
+		easter_egg_9  = "<ch>תיזהר, הזמן עובר מהר...",
+		easter_egg_10 = "<ch>פשוט שב ותירגע, מחר יגיע במהרה!",
+		easter_egg_11 = "<ch>לך לישון מוקדם, זה יגרום לזמן לעבור מהר יותר!",
+		easter_egg_12 = "<ch>סבלנות היא מעלה",
+		easter_egg_13 = "<ch>https://youtu.be/9jK-NcRmVcw",
+		double_maps = "<bv>מפות כפולות וכל הכוחות זמינים בשביל שבוע היום הולדת של פארקור!",
+		double_maps_start = "<rose>זה שבוע היום הולדת של פארקור! מפות כפולות וכל הכוחות הופעלו.תודה שאתם משחקים איתנו!",
+		double_maps_end = "<rose>שבוע היום הולדת של פארקור נגמר. תודה ששיחקתם!",
+
+		-- Records
+		records_enabled = "<v>[#] <d>מצב שיאים הופעל בחדר זה. סטטיסטיקה לא תיחשב וכוחות לא יפעלו. תוכלו למצוא מידע נוסף על שיאים ב <b>%s</b>",
+		records_admin = "<v>[#] <d>הנך מנהל של חדר השיאים הזה. אתה יכול להשתמש בפקודות <b>!map</b>, <b>!setcp</b>, <b>!pw</b> ו-<b>!time</b>.",
+		records_completed = "<v>[#] <d>השלמתם את המפה! אם ברצונכם להשלימה שוב, כתבו <b>!redo</b>.",
+		records_submit = "<v>[#] <d>וואו! נראה שיש לכם את הזמן הכי מהיר בחדר. אם ברצונכם להגיש את השיא, כתבו <b>!submit</b>.",
+		records_invalid_map = "<v>[#] <r>נראה כי מפה זו אינה חלק ממפות פארקור... אינכם יכולים להגיש שיא בשבילה!",
+		records_not_fastest = "<v>[#] <r>נראה כי אינך השחקן הכי מהיר בחדר...",
+		records_already_submitted = "<v>[#] <r>כבר הגשת את השיא שלך בשביל מפה זו!",
+		records_submitted = "<v>[#] <d>השיא שלך למפה <b>%s</b> הוגש.",
+
+		-- Miscellaneous
+		afk_popup = "\n<p align='center'><font size='30'><bv><b>אתה במצב AFK</b></bv>\nזוז כדי לחזור</font>\n\n<font size='30'><u><t>תזכורות:</t></u></font>\n\n<font size='15'><r>שחקנים עם קו אדום מעליהם אינם מעוניינים בעזרה!\nהטרלת/חסימת שחקנים אחרים בפארקור אסורה!<d>\nהצטרפו ל<cep><a href='event:discord'>שרת הדיסקורד</a></cep> שלנו!\nרוצה לתרום קוד? ראה את <cep><a href='event:github'>מאגר ה-GitHub</a></cep> שלנו.\nיש לך מפה טובה להגיש?  שלח את זה ב<cep><a href='event:map_submission'>נושא הגשת המפות</a></cep> שלנו\nבידקו את <cep><a href='event:forum'>הנושא הרשמי</a></cep> שלנו למידע נוסף!\nתמוך בנו על ידי <cep><a href='event:donate'>תרומה!</a></cep>",
+		options = "<p align='center'><font size='20'>אפשרויות פארקור</font></p>\n\nהשתמש במקלדת <b>QWERTY</b> (כבה אם <b>AZERTY</b> בשימוש)\n\nהשתמש באות <b>צ</b> במקום <b>/mort</b> (משבית את <b>DEL</b>)\n\nהראה את זמן טעינת הכוחות\n\nהראה כפתור כוחות\n\nהראה כפתור עזרה\n\nהראה הכרזות השלמת מפות\n\nהצג סימן 'ללא עזרה'",
+		cooldown = "<v>[#] <r>המתן מספר שניות לפני שאתה עושה זאת.",
+		power_options = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><b>QWERTY</b> מקלדת" ..
+						 "\n\n<b>הסתר</b> ספירת מפות" ..
+						 "\n\nהשתמש ב<b>מקשים מקוריים</b>"),
+		unlock_power = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>השלם <v>%s</v> מפות" ..
+						"<font size='5'>\n\n</font>בכדי להשיג" ..
+						"<font size='5'>\n\n</font><v>%s</v>"),
+		upgrade_power = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>השלם <v>%s</v> מפות" ..
+						"<font size='5'>\n\n</font>כדי לשדרג ל" ..
+						"<font size='5'>\n\n</font><v>%s</v>"),
+		unlock_power_rank = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>דרגה <v>%s</v>" ..
+						"<font size='5'>\n\n</font>בכדי להשיג" ..
+						"<font size='5'>\n\n</font><v>%s</v>"),
+		upgrade_power_rank = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>דרגה <v>%s</v>" ..
+						"<font size='5'>\n\n</font>כדי לשדרג ל" ..
+						"<font size='5'>\n\n</font><v>%s</v>"),
+		maps_info = ("<p align='center'><font size='13' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
+					 "<font size='5'>\n\n</font>מפות שהושלמו"),
+		overall_info = ("<p align='center'><font size='13' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
+						"<font size='5'>\n\n</font>לוח תוצאות כללי"),
+		weekly_info = ("<p align='center'><font size='13' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
+					   "<font size='5'>\n\n</font>לוח תוצאות שבועי"),
+		badges = "<font size='14' face='Lucida Console,Liberation Mono,Courier New,Verdana'>תגים (%s): <a href='event:_help:badge'><j>[?]</j></a>",
+		private_maps = "<bl>מספר המפות של שחקן זה הינו פרטי. <a href='event:_help:private_maps'><j>[?]</j></a></bl>\n",
+		profile = ("<font size='12' face='Lucida Console,Liberation Mono,Courier New,Verdana'>%s%s %s\n\n" ..
+					"דרגה בלוח התוצאות הכללי: <b><v>%s</v></b>\n\n" ..
+					"דרגה בלוח התוצאות השבועי: <b><v>%s</v></b>\n\n%s"),
+		map_count = "מספר מפות: <b><v>%s</v> / <a href='event:_help:yellow_maps'><j>%s</j></a> / <a href='event:_help:red_maps'><r>%s</r></a></b>",
+		help_badge = "תגים הינם הישגים ששחקן יכול לקבל. לחץ עליהם על מנת לקבל פירוט.",
+		help_private_maps = "משתמש זה אינו מעוניין לשתף את מספר המפות שלו בפומבי! אתה יכול להסתיר את זה גם בפרופיל שלך.",
+		help_yellow_maps = "מפות בצהוב הן מפות שהושלמו בשבוע זה.",
+		help_red_maps = "מפות באדום הן מפות שהושלמו בשעה האחרונה.",
+		help_badge_1 = "משתמש זה היה חלק מצוות הפארקור בעבר.",
+		help_badge_2 = "משתמש זה נמצא או היה בעמוד הראשון של לוח התוצאות הכללי.",
+		help_badge_3 = "משתמש זה נמצא או היה בעמוד השני של לוח התוצאות הכללי.",
+		help_badge_4 = "משתמש זה נמצא או היה בעמוד השלישי של לוח התוצאות הכללי.",
+		help_badge_5 = "משתמש זה נמצא או היה בעמוד הרביעי של לוח התוצאות הכללי.",
+		help_badge_6 = "משתמש זה נמצא או היה בעמוד החמישי של לוח התוצאות הכללי.",
+		help_badge_7 = "שחקן זה היה בפודיום בסוף של לוח התוצאות השבועי בסוף שבוע",
+		help_badge_8 = "השחקן הזה השיג שיא של 30 מפות תוך שעה.",
+		help_badge_9 = "השחקן הזה השיג שיא של 35 מפות תוך שעה.",
+		help_badge_10 = "השחקן הזה השיג שיא של 40 מפות תוך שעה.",
+		help_badge_11 = "השחקן הזה השיג שיא של 45 מפות תוך שעה.",
+		help_badge_12 = "השחקן הזה השיג שיא של 50 מפות תוך שעה.",
+		help_badge_13 = "השחקן הזה השיג שיא של 55 מפות תוך שעה.",
+		help_badge_14 = "שחקן זה אימת את משתמש הדיסקורד שלו בשרת הדיסקורד הרשמי של פארקור (כתבו <b>!discord</b>).",
+		help_badge_15 = "שחקן זה עשה את הזמן המהיר ביותר במפה אחת.",
+		help_badge_16 = "שחקן זה עשה את הזמן המהיר ביותר ב-5 מפות.",
+		help_badge_17 = "שחקן זה עשה את הזמן המהיר ביותר ב-10 מפות.",
+		help_badge_18 = "שחקן זה עשה את הזמן המהיר ביותר ב-15 מפות.",
+		help_badge_19 = "שחקן זה עשה את הזמן המהיר ביותר ב-20 מפות.",
+		help_badge_20 = "שחקן זה עשה את הזמן המהיר ביותר ב-25 מפות.",
+		help_badge_21 = "שחקן זה עשה את הזמן המהיר ביותר ב-30 מפות.",
+		help_badge_22 = "שחקן זה עשה את הזמן המהיר ביותר ב-35 מפות.",
+		help_badge_23 = "שחקן זה עשה את הזמן המהיר ביותר ב-40 מפות.",
+		make_public = "הפוך לציבורי",
+		make_private = "הפוך לפרטי",
+		moderators = "מנהלים",
+		mappers = "צוות מפות",
+		managers = "מנהלי צוות",
+		administrators = "אדמינים",
+		close = "סגור",
+		cant_load_bot_profile = "<v>[#] <r>אינך יכול לראות את הפרופיל של הבוט הזה כיוון שפארקור משתמש בו באופן פנימי כדי לעבוד בצורה ראויה.",
+		cant_load_profile = "<v>[#] <r>השחקן <b>%s</b> ככל הנראה מנותק או איננו קיים.",
+		like_map = "האם אתה אוהב את המפה הזו?",
+		yes = "כן",
+		no = "לא",
+		idk = "לא יודע",
+		unknown = "לא ידוע",
+		powers = "כוחות",
+		press = "<vp>לחץ %s",
+		click = "<vp>לחיצה שמאלית",
+		ranking_pos = "דרגה #%s",
+		completed_maps = "<p align='center'><BV><B>מפות שהושלמו: %s</B></p></BV>",
+		leaderboard = "לוח תוצאות",
+		position = "<V><p align=\"center\">דרגה",
+		username = "<V><p align=\"center\">שם משתמש",
+		community = "<V><p align=\"center\">קהילה",
+		completed = "<V><p align=\"center\">מפות שהושלמו",
+		overall_lb = "כללי",
+		weekly_lb = "שבועי",
+		new_lang = "<v>[#] <d>השפה הוגדרה ל-עברית",
+
+		-- Power names
+		balloon = "בלון",
+		masterBalloon = "מאסטר בלון",
+		bubble = "בועה",
+		fly = "תעופה",
+		snowball = "כדור שלג",
+		speed = "מהירות",
+		teleport = "שיגור",
+		smallbox = "קופסא קטנה",
+		cloud = "ענן",
+		rip = "קבר",
+		choco = "קרש שוקולד",
+		bigBox = "קופסא גדולה",
+		trampoline = "טרמפולינה",
+		toilet = "אסלה",
+		pig = "חזיר",
+		sink = "כיור",
+		bathtub = "אמבטיה",
+		campfire = "מדורה",
+		chair = "כסא",
+	}
+	--[[ End of file translations/parkour/he.lua ]]--
+	--[[ File translations/parkour/ru.lua ]]--
+	translations.ru = {
+		name = "ru",
+		fullname = "Русский",
+
+		-- Сообщения об ошибках
+		corrupt_map = "<r>Поврежденная карта. загрузите другую.",
+		corrupt_map_vanilla = "<r>[ОШИБКА] <n>Не удается получить информацию о карте.",
+		corrupt_map_mouse_start = "<r>[ОШИБКА] <n>Карта должна иметь начальную позицию (точку появления мыши).",
+		corrupt_map_needing_chair = "<r>[ОШИБКА] <n>На карте должно находиться кресло для окончания раунда.",
+		corrupt_map_missing_checkpoints = "<r>[ОШИБКА] <n>Карта должна иметь хотя бы один чекпоинт (желтый гвоздь).",
+		corrupt_data = "<r>К сожалению, ваши данные повреждены и были сброшены.",
+		min_players = "<r>Чтобы сохранить ваши данные, в комнате должно быть как минимум 4 уникальных игрока. <bl>[%s/%s]",
+		tribe_house = "<r>Данные не будут сохранены в комнате племени.",
+		invalid_syntax = "<r>Неверный синтаксис.",
+		code_error = "<r>Появилась ошибка: <bl>%s-%s-%s %s",
+		emergency_mode = "<r>Активировано аварийное отключение, новые игроки не смогут зайти. Пожалуйста, перейдите в другую комнату #pourour.",
+		leaderboard_not_loaded = "<r>Таблица лидеров еще не загружена. Подождите минуту.",
+		max_power_keys = "<v>[#] <r>You can only have at most %s powers in the same key.",
+
+		-- Help window
+		help = "Помощь",
+		staff = "Команда модераторов",
+		rules = "Правила",
+		contribute = "Содействие",
+		changelog = "Изменения",
+		help_help = "<p align = 'center'><font size = '14'>Добро пожаловать в <T>#parkour!</T></font></p>\n<font size = '12'><p align='center'><J>Ваша цель - собрать все чекпоинты, чтобы завершить карту.</J></p>\n\n<N>• Нажмите <O>O</O>, введите <O>!op</O> или нажмите на <O> шестеренку</O> чтобы открыть <T>меню настроек</T>.\n• Нажмите <O>P</O> или нажмите на <O>руку</O> в правом верхнем углу, чтобы открыть <T>меню со способностями</T>.\n• Нажмите <O>L</O> или введите <O>!lb</O> чтобы открыть <T>Список лидеров</T>.\n• Нажмите <O>M</O> или <O>Delete</O> чтобы не прописывать <T>/mort</T>.\n• Чтобы узнать больше о нашей <O>команде</O> и о <O>правилах паркура</O>, нажми на <T>Команда</T> и <T>Правила</T>.\n• Нажмите <a href='event:discord'><o>here</o></a> чтобы получить ссылку на приглашение в наш Дискорд канал. Нажмите <a href='event:map_submission'><o>here</o></a> чтобы получить ссылку на тему отправки карты.\n• Используйте клавиши <o>вверх</o> и <o>вниз</o> чтобы листать меню.\n\n<p align = 'center'><font size = '13'><T>Вкладки теперь открыты! Для получения более подробной информации, нажмите на вкладку <O>Содействие</O> !</T></font></p>",
+		help_staff = "<p align = 'center'><font size = '13'><r>ОБЯЗАННОСТИ: Команда Паркура НЕ команда Transformice и НЕ имеет никакой власти в самой игре, только внутри модуля.</r>\nКоманда Parkour обеспечивают исправную работу модуля с минимальными проблемами и всегда готова помочь игрокам в случае необходимости.</font></p>\nВы можете ввести <D>!staff</D> в чат, чтобы увидеть нашу команду.\n\n<font color = '#E7342A'>Администраторы:</font> Hесут ответственность за поддержку самого модуля, добавляя новые обновления и исправляя ошибки.\n\n<font color = '#D0A9F0'>Руководители команд:</font> Kонтролируют команды модераторов и картостроителей, следя за тем, чтобы они хорошо выполняли свою работу. Они также несут ответственность за набор новых членов в команду.\n\n<font color = '#FFAAAA'>Модераторы:</font> Hесут ответственность за соблюдение правил модуля и наказывают тех, кто не следует им.\n\n<font color = '#25C059'>Картостроители:</font> Oтвечают за просмотр, добавление и удаление карт в модуле, обеспечивая вам приятный игровой процесс.",
+		help_rules = "<font size = '13'><B><J>Все правила пользователя и условия Transformice также применяются к #parkour </J></B></font>\n\nЕсли вы обнаружили, что кто-то нарушает эти правила, напишите нашим модераторам. Если модераторов нет в сети, вы можете сообщить об этом на на нашем сервере в Discord\nПри составлении репорта, пожалуйста, укажите сервер, имя комнаты и имя игрока.\n• Пример: en-#parkour10 Blank#3495 троллинг\nДоказательства, такие как скриншоты, видео и гифки, полезны и ценны, но не обязательны.\n\n<font size = '11'>• <font color = '#ef1111'>читы, глюки или баги</font> не должны использоваться в комнатах #parkour\n• <font color = '#ef1111'>Фарм через VPN</font> считается <B>нарушением</B> и не допускается. <p align = 'center'><font color = '#cc2222' size = '12'><B>\nЛюбой, кто пойман за нарушение этих правил, будет немедленно забанен.</B></font></p>\n\n<font size = '12'>Transformice позволяет концепцию троллинга. Однако, <font color='#cc2222'><B>мы не допустим этого в паркуре.</B></font></font>\n\n<p align = 'center'><J>Троллинг - это когда игрок намеренно использует свои силы или инвентарь, чтобы помешать другим игрокам пройти/закончить карту.</J></p>\n• Троллинг ради мести <B>не является веской причиной,</B> для троллинга кого-либо и вы все равно будете наказаны.\n• Принудительная помощь игрокам, которые пытаются пройти карту самостоятельно и отказываюся от помощи, когда их об этом просят, также считается троллингом. \n• <J>Если игрок не хочет помогать или предпочитает играть в одиночку на карте, постарайтесь помочь другим игрокам</J>. Однако, если другой игрок нуждается в помощи на том же чекпоинте, что и соло игрок, вы можете помочь им [обоим].\n\nЕсли игрок пойман за троллингом, он будет наказан на временной основе. Обратите внимание, что повторный троллинг приведет к более длительным и суровым наказаниям.",
+		help_contribute = "<font size='14'>\n<p align='center'>Команда управления паркуром предпочитает открытый исходный код, потому что он <t>помогает сообществу</t>. Вы можете <o>посмотреть</o> и <o>улучшить</o> исходный код на <o><u><a href='event:github'>GitHub</a></u></o>.\nПоддержание модуля<t>строго добровольно</t>, так что любая помощь в отношении <t>code</t>, <t>баг репортов</t>, <t>предложений</t> and <t>созданию карт</t> is always <u>приветствуется и ценится</u>.\nВы можете <vp>оставлять жалобу</vp> и <vp>предлагать улучшения</vp> в нашем <o><u><a href='event:discord'>Дискорде</a></u></o> и/или в <o><u><a href='event:github'>GitHub</a></u></o>.\nВы можете <vp>отправить свои карты</vp> на нашем <o><u><a href='event:map_submission'>форуме</a></u></o>.\n\nПоддержание паркура не дорогое, но и не бесплатное. Мы будем рады, если вы поможете нам <t>любой суммой</t> <o><u><a href='event:donate'>here</a></u></o>.\n<u>Все пожертвования пойдут на улучшение модуля.</u></p>",
+		help_changelog = "<font size='13'><p align='center'><o>Version 2.10.0 - 17/04/2021</o></p>\n\n<font size='11'>• <font size='13'><b><j>THREE</J></b> brand new Transformice titles that can only be unlocked by playing <font color='#1A7EC9'><b>#parkour</b></font>!</font>\n• Two new statuses added to the profile.\n• Minor text adjustments.",
+
+		-- Congratulation messages
+		reached_level = "<d>Поздравляем! Вы достигли уровня <vp>%s</vp>. (<t>%ss</t>)",
+		finished = "<d><o>%s</o> завершил паркур за <vp>%s</vp> секунд, <fc>поздравляем!",
+		unlocked_power = "<ce><d>%s</d> разблокировал способность <vp>%s</vp>.",
+
+		-- Information messages
+		mod_apps = "<j>Приложения паркура модератора теперь открыты! Используйте эту ссылку: <rose>%s",
+		staff_power = "<r>Команда паркура <b>не</b> имеет власти вне #parkour комнат.",
+		donate = "<vp>Введите <b>!donate</b>, если хотите пожертвовать на этот модуль!",
+		paused_events = "<cep><b>[Предупреждение!]</b> <n> Модуль достиг критического предела и сейчас временно остановлен.",
+		resumed_events = "<n2>Модуль был возобновлен.",
+		welcome = "<n>Добро пожаловать в<t>#parkour</t>!",
+		module_update = "<r><b>[Предупреждение!]</b> <n>Модуль будет обновлен в <d>%02d:%02d</d>.",
+		leaderboard_loaded = "<j>Таблица лидеров была загружена. Нажмите L, чтобы открыть ее.",
+		kill_minutes = "<R>Ваши способности отключены на %s минут.",
+		permbanned = "<r>Вы были навсегда забанены в #parkour.",
+		tempbanned = "<r>Вы были забанены в #parkour на %s минут.",
+		forum_topic = "<rose>Для получения дополнительной информации о модуле посетите эту ссылку: %s",
+		report = "<j>Хотите пожаловаться на игрока? <t><b>/c Parkour#8558 .report Никнейм#0000</b></t>",
+
+		-- Easter Eggs
+		easter_egg_0  = "<ch>Итак, наступает обратный отсчет...",
+		easter_egg_1  = "<ch>Остается меньше, чем 24 часа!",
+		easter_egg_2  = "<ch>Вау, ты пришел очень рано! Ты слишком взволнован?",
+		easter_egg_3  = "<ch>Ожидается сюрприз...",
+		easter_egg_4  = "<ch>Ты знаешь о том, что должно произойти...?",
+		easter_egg_5  = "<ch>Часы продолжают тикать...",
+		easter_egg_6  = "<ch>Сюрприз близок!",
+		easter_egg_7  = "<ch>Вечеринка скоро начнется...",
+		easter_egg_8  = "<ch>Взгляни на часы, не пора ли?",
+		easter_egg_9  = "<ch>Будь осторожен, время идет...",
+		easter_egg_10 = "<ch>Просто сядь и расслабься, это будет завтра в кратчайшие сроки!",
+		easter_egg_11 = "<ch>Давай ляжем спать пораньше, это сделает время быстрее!",
+		easter_egg_12 = "<ch>Терпение это добродетель",
+		easter_egg_13 = "<ch>https://youtu.be/9jK-NcRmVcw",
+		double_maps = "<bv>Удвоенные карты и все силы доступы на неделе рождения паркура!",
+		double_maps_start = "<rose>ЭТО НЕДЕЛЯ РОЖДЕНИЯ ПАРКУРА! Удвоенные карты и все силы были активированы. Спасибо за то, что играешь с нами!",
+		double_maps_end = "<rose>Неделя рождения паркура закончилась. Спасибо за то, что играешь с нами!",
+
+		-- Records
+		records_enabled = "<v>[#] <d>RВ этой комнате включен режим рекордов. Статистика не учитывается, а умения отключены!\nВы можете найти больше информации в <b>%s</b>",
+		records_admin = "<v>[#] <d>Вы администратор этой комнаты. Вы можете использовать команды <b>!map</b>, <b>!setcp</b>, <b>!pw</b> и <b>!time</b>.",
+		records_completed = "<v>[#] <d>Вы прошли карту! Если вы хотите сделать это заново, введите <b>!redo</b>.",
+		records_submit = "<v>[#] <d>Вот Это Да! Похоже, ты быстрее всех прошел карту. Если хочешь поделиться своим рекордом, введи  <b>!submit</b>.",
+		records_invalid_map = "<v>[#] <r>Похоже, эта карта не в ротации паркура ... Вы не можете сохранить рекорд для нее!",
+		records_not_fastest = "<v>[#] <r>Кажется, ты не самый быстрый игрок в комнате ...",
+		records_already_submitted = "<v>[#] <r>Вы уже отправили свой рекорд для этой карты!",
+		records_submitted = "<v>[#] <d>Ваш рекорд на этой карте <b>%s</b> был сохранен.",
+
+		-- Miscellaneous
+		afk_popup = "\n<p align='center'><font size='30'><bv><b>YOU'RE ON AFK MODE</b></bv>\nMOVE TO RESPAWN</font>\n\n<font size='30'><u><t>Reminders:</t></u></font>\n\n<font size='15'><r>Players with a red line over them don't want help!\nTrolling/blocking other players in parkour is NOT allowed!<d>\nJoin our <cep><a href='event:discord'>discord server</a></cep>!\nWant to contribute with code? See our <cep><a href='event:github'>github repository</a></cep>\nDo you have a good map to submit? Post it in our <cep><a href='event:map_submission'>map submission topic</a></cep>\nCheck our <cep><a href='event:forum'>official topic</a></cep> for more information!\nSupport us by <cep><a href='event:donate'>donating!</a></cep>",
+		options = "<p align='center'><font size='20'>Параметры Паркура</font></p>\n\nИспользуйте <b>QWERTY</b> на клавиатуре (отключить if <b>AZERTY</b>)\n\nИспользуйте <b>M</b> горячую клавишу <b>/mort</b> (отключить <b>DEL</b>)\n\nПоказать ваше время перезарядки\n\nПоказать кнопку способностей\n\nПоказать кнопку помощь\n\nПоказать объявление о завершении карты\n\nПоказать символ помощь не нужна",
+		cooldown = "<v>[#] <r>Подождите несколько минут, чтобы повторить действие.",
+		power_options = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><b>QWERTY</b> клавиатура" ..
+						 "\n\n<b>Hide</b> map count" ..
+						 "\n\nUse <b>default key</b>"),
+		unlock_power = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Пройденные <v>%s</v> карты" ..
+						"<font size='5'>\n\n</font>разблокированы" ..
+						"<font size='5'>\n\n</font><v>%s</v>"),
+		upgrade_power = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Пройденные <v>%s</v> карты" ..
+						"<font size='5'>\n\n</font>обновлены" ..
+						"<font size='5'>\n\n</font><v>%s</v>"),
+		unlock_power_rank = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Ранг <v>%s</v>" ..
+						"<font size='5'>\n\n</font>разбокирован" ..
+						"<font size='5'>\n\n</font><v>%s</v>"),
+		upgrade_power_rank = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Ранг <v>%s</v>" ..
+						"<font size='5'>\n\n</font>обновлен" ..
+						"<font size='5'>\n\n</font><v>%s</v>"),
+		maps_info = ("<p align='center'><font size='13' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
+					 "<font size='5'>\n\n</font>Пройденые карты"),
+		overall_info = ("<p align='center'><font size='13' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
+						"<font size='5'>\n\n</font>Общая таблица лидеров"),
+		weekly_info = ("<p align='center'><font size='13' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
+					   "<font size='5'>\n\n</font>Еженедельная таблица лидеров"),
+		badges = "<font size='14' face='Lucida Console,Liberation Mono,Courier New,Verdana'>Badges (%s): <a href='event:_help:badge'><j>[?]</j></a>",
+		private_maps = "<bl>Количество карт этого игрока является частным.<a href='event:_help:private_maps'><j>[?]</j></a></bl>\n",
+		profile = ("<font size='12' face='Lucida Console,Liberation Mono,Courier New,Verdana'>%s%s %s\n\n" ..
+					"Общая таблица лидеров: <b><v>%s</v></b>\n\n" ..
+					"Еженедельначя таблица лидеров: <b><v>%s</v></b>\n\n%s"),
+		map_count = "Количество карт: <b><v>%s</v> / <a href='event:_help:yellow_maps'><j>%s</j></a> / <a href='event:_help:red_maps'><r>%s</r></a></b>",
+		help_badge = "Значки - это достижение, которое может получить игрок. Нажмите на них, чтобы увидеть их описание.",
+		help_private_maps = "Этот игрок не любит публично публиковать количество своих карт! Вы также можете скрыть их в своем профиле.",
+		help_yellow_maps = "Желтым цветом обозначены карты, завершенные на этой неделе.",
+		help_red_maps = "Карты красного цвета - это карты, завершенные за последний час.",
+		help_badge_1 = "Этот игрок в прошлом был сотрудником паркура.",
+		help_badge_2 = "Этот игрок находится или был на странице 1 общей таблицы лидеров.",
+		help_badge_3 = "Этот игрок находится или был на странице 2 общей таблицы лидеров.",
+		help_badge_4 = "Этот игрок находится или был на странице 3 общей таблицы лидеров.",
+		help_badge_5 = "Этот игрок находится или был на странице 4 общей таблицы лидеров.",
+		help_badge_6 = "Этот игрок находится или был на странице 5 общей таблицы лидеров.",
+		help_badge_7 = "Этот игрок был в еженедельной таблицы лидеров.",
+		help_badge_8 = "У этого игрока рекорд - 30 карт в час.",
+		help_badge_9 = "У этого игрока рекорд - 35 карт в час.",
+		help_badge_10 = "У этого игрока рекорд - 40 карт в час.",
+		help_badge_11 = "У этого игрока рекорд - 45 карт в час.",
+		help_badge_12 = "У этого игрока рекорд - 50 карт в час.",
+		help_badge_13 = "У этого игрока рекорд - 55 карт в час.",
+		help_badge_14 = "Этот пользователь подтвердил свою учетную запись на официальном канале сервера паркура (нажмите <b>!discord</b>).",
+		help_badge_15 = "Этот игрок показал лучшее время на 1 карте.",
+		help_badge_16 = "Этот игрок показал лучшее время на 5 картах.",
+		help_badge_17 = "Этот игрок показал лучшее время на 10 картах.",
+		help_badge_18 = "Этот игрок показал лучшее время на 15 картах.",
+		help_badge_19 = "Этот игрок показал лучшее время на 20 картах.",
+		help_badge_20 = "Этот игрок показал лучшее время на 25 картах.",
+		help_badge_21 = "Этот игрок показал лучшее время на 30 картах.",
+		help_badge_22 = "Этот игрок показал лучшее время на 35 картах.",
+		help_badge_23 = "Этот игрок показал лучшее время на 40 картах.",
+		make_public = "сделать публичным",
+		make_private = "сделать приватым",
+		moderators = "Модераторы",
+		mappers = "Maпперы",
+		managers = "Mенеджеры",
+		administrators = "Администрация",
+		close = "Закрыть",
+		cant_load_bot_profile = "<v>[#] <r>You can't see this bot's profile since #parkour uses it internally to work properly.",
+		cant_load_profile = "<v>[#] <r>The player <b>%s</b> seems to be offline or does not exist.",
+		like_map = "Do you like this map?",
+		yes = "Yes",
+		no = "No",
+		idk = "I don't know",
+		unknown = "Неизвестно",
+		powers = "Способности",
+		press = "<vp>Нажмите %s",
+		click = "<vp>Щелчок левой кнопкой мыши",
+		ranking_pos = "Рейтинг #%s",
+		completed_maps = "<p align='center'><BV><B>Пройденные карты: %s</B></p></BV>",
+		leaderboard = "Таблица лидеров",
+		position = "<V><p align=\"center\">Должность",
+		username = "<V><p align=\"center\">Имя пользователя",
+		community = "<V><p align=\"center\">Сообщество",
+		completed = "<V><p align=\"center\">Пройденные карты",
+		overall_lb = "В целом",
+		weekly_lb = "Еженедельно",
+		new_lang = "<v>[#] <d>Язык установлен на Русский",
+
+		-- Power names
+		balloon = "Шар",
+		masterBalloon = "Мастер шар",
+		bubble = "Пузырь",
+		fly = "Полет",
+		snowball = "Снежок",
+		speed = "Скорость",
+		teleport = "Телепорт",
+		smallbox = "Маленький ящик",
+		cloud = "Облако",
+		rip = "Могила",
+		choco = "Шоколадная палка",
+		bigBox = "Большая коробка",
+		trampoline = "Батут",
+		toilet = "Туалет",
+		pig = "Свинья",
+		sink = "тонуть",
+		bathtub = "Ванна",
+		campfire = "Костёр",
+		chair = "Стул",
+	}
+	--[[ End of file translations/parkour/ru.lua ]]--
 	--[[ File translations/parkour/pl.lua ]]--
 	translations.pl = {
 		name = "pl",
@@ -1820,6 +2779,199 @@ local function initialize_parkour() -- so it uses less space after building
 		chair = "Sandalye",
 	}
 	--[[ End of file translations/parkour/tr.lua ]]--
+	--[[ File translations/parkour/es.lua ]]--
+	translations.es = {
+		name = "es",
+		fullname = "Español",
+
+		-- Error messages
+		corrupt_map = "<r>Mapa corrupto. Cargando otro.",
+		corrupt_map_vanilla = "<r>[ERROR] <n>No se pudo obtener información de este mapa.",
+		corrupt_map_mouse_start = "<r>[ERROR] <n>El mapa tiene que tener un punto de inicio de los ratones.",
+		corrupt_map_needing_chair = "<r>[ERROR] <n>El mapa tiene que tener el sillón del final.",
+		corrupt_map_missing_checkpoints = "<r>[ERROR] <n>El mapa tiene que tener al menos un checkpoint (anclaje amarillo).",
+		corrupt_data = "<r>Tristemente, tus datos estaban corruptos. Se han reiniciado.",
+		min_players = "<r>Para guardar datos, deben haber al menos 4 jugadores únicos en la sala. <bl>[%s/%s]",
+		tribe_house = "<r>Para guardar datos, debes jugar fuera de una casa de tribu.",
+		invalid_syntax = "<r>Sintaxis inválida.",
+		code_error = "<r>Apareció un error: <bl>%s-%s-%s %s",
+		emergency_mode = "<r>Empezando apagado de emergencia, no se admiten más jugadores. Por favor ve a otra sala #parkour.",
+		leaderboard_not_loaded = "<r>La tabla de clasificación aun no ha sido cargada. Espera un minuto.",
+		max_power_keys = "<v>[#] <r>Solo puedes tener como máximo %s poderes en la misma tecla.",
+
+		-- Help window
+		help = "Ayuda",
+		staff = "Staff",
+		rules = "Reglas",
+		contribute = "Contribuir",
+		changelog = "Novedades",
+		help_help = "<p align = 'center'><font size = '14'>¡Bienvenido a <T>#parkour!</T></font></p>\n<font size = '12'><p align='center'><J>Tu objetivo es alcanzar todos los checkpoints hasta que completes el mapa.</J></p>\n\n<N>• Presiona la tecla <O>O</O>, escribe <O>!op</O> o clickea el <O>botón de configuración</O> para abrir el <T>menú de opciones</T>.\n• Presiona la tecla <O>P</O> o clickea el <O>ícono de la mano</O> arriba a la derecha para abrir el <T>menú de poderes</T>.\n• Presiona la tecla <O>L</O> o escribe <O>!lb</O> para abrir el <T>ranking</T>.\n• Presiona la tecla <O>M</O> o <O>Delete</O> como atajo para <T>/mort</T>, podes alternarlas en el menú de <J>Opciones</J>.\n• Para conocer más acerca de nuestro <O>staff</O> y las <O>reglas de parkour</O>, clickea en las pestañas de <T>Staff</T> y <T>Reglas</T>.\n• Click <a href='event:discord'><o>here</o></a> to get the discord invite link and <a href='event:map_submission'><o>here</o></a> to get the map submission topic link.\n• Use <o>up</o> and <o>down</o> arrow keys when you need to scroll.\n\n<p align = 'center'><font size = '13'><T>¡Las contribuciones están abiertas! Para más detalles, ¡clickea en la pestaña <O>Contribuir</O>!</T></font></p>",
+		help_staff = "<p align = 'center'><font size = '13'><r>NOTA: El staff de Parkour NO ES staff de Transformice y NO TIENEN ningún poder en el juego, sólamente dentro del módulo.</r>\nEl staff de Parkour se asegura de que el módulo corra bien con la menor cantidad de problemas, y siempre están disponibles para ayudar a los jugadores cuando sea necesario.</font></p>\nPuedes escribir <D>!staff</D> en el chat para ver la lista de staff.\n\n<font color = '#E7342A'>Administradores:</font> Son los responsables de mantener el módulo añadiendo nuevas actualizaciones y arreglando bugs.\n\n<font color = '#D0A9F0'>Lideres de Equipos:</font> Ellos supervisan los equipos de Moderadores y Mappers, asegurándose de que hagan un buen trabajo. También son los responsables de reclutar nuevos miembros al staff.\n\n<font color = '#FFAAAA'>Moderadores:</font> Son los responsables de ejercer las reglas del módulo y sancionar a quienes no las sigan.\n\n<font color = '#25C059'>Mappers:</font> Son los responsables de revisar, añadir y quitar mapas en el módulo para asegurarse de que tengas un buen gameplay.",
+		help_rules = "<font size = '13'><B><J>Todas las reglas en los Terminos y Condiciones de Transformice también aplican a #parkour</J></B></font>\n\nSi encuentras algún jugador rompiendo estas reglas, susurra a los moderadores de parkour en el juego. Si no hay moderadores online, es recomendable reportarlo en discord.\nCuando reportes, por favor agrega el servidor, el nombre de la sala, y el nombre del jugador.\n• Ej: en-#parkour10 Blank#3495 trollear\nEvidencia, como fotos, videos y gifs ayudan y son apreciados, pero no son necesarios.\n\n<font size = '11'>• No se permite el uso de <font color = '#ef1111'>hacks, glitches o bugs</font>\n• <font color = '#ef1111'>Farmear con VPN</font> será considerado un <B>abuso</B> y no está permitido. <p align = 'center'><font color = '#cc2222' size = '12'><B>\nCualquier persona rompiendo estas reglas será automáticamente baneado.</B></font></p>\n\n<font size = '12'>Transformice acepta el concepto de trollear. Pero <font color='#cc2222'><B>no está permitido en #parkour.</B></font></font>\n\n<p align = 'center'><J>Trollear es cuando un jugador intencionalmente usa sus poderes o consumibles para hacer que otros jugadores no completen el mapa.</j></p>\n• Trollear como venganza <B>no es una razón válida</B> para trollear a alguien y aún así seras sancionado.\n• Ayudar a jugadores que no quieren completar el mapa con ayuda y no parar cuando te lo piden también es considerado trollear.\n• <J>Si un jugador no quiere ayuda, por favor ayuda a otros jugadores</J>. Sin embargo, si otro jugador necesita ayuda en el mismo punto, puedes ayudarlos [a los dos].\n\nSi un jugador es atrapado trolleando, será sancionado en base de tiempo. Trollear repetidas veces llevará a sanciones más largas y severas.",
+		help_contribute = "<font size='14'>\n<p align='center'>El equipo de administración de parkour ama el codigo abierto porque <t>ayuda a la comunidad</t>. Podés <o>ver</o> y <o>modificar</o> el código de parkour en <o><u><a href='event:github'>GitHub</a></u></o>.\n\nMantener el módulo es <t>estrictamente voluntario</t>, por lo que cualquier ayuda con respecto al <t>código</t>, <t>reportes de bugs</t>, <t>sugerencias</t> y <t>creación de mapas</t> siempre será <u>bienvenida y apreciada</u>.\nPodés <vp>reportar bugs</vp> y <vp>dar sugerencias</vp> en <o><u><a href='event:discord'>Discord</a></u></o> y/o <o><u><a href='event:github'>GitHub</a></u></o>.\nPodés <vp>enviar tus mapas</vp> en nuestro <o><u><a href='event:map_submission'>Hilo del Foro</a></u></o>.\n\nMantener parkour no es caro, pero tampoco es gratis. Realmente apreciaríamos si pudieras ayudarnos <t>donando cualquier cantidad</t> <o><u><a href='event:donate'>aquí</a></u></o>.\n<u>Todas las donaciones serán destinadas a mejorar el módulo.</u></p>",
+		help_changelog = "<font size='13'><p align='center'><o>Version 2.10.0 - 17/04/2021</o></p>\n\n<font size='11'>• <font size='13'>¡<b><j>TRES</J></b> nuevos títulos fueron añadidos a Transformice que solamente pueden ser desbloqueados al jugar <font color='#1A7EC9'><b>#parkour</b></font>!</font>\n• Dos nuevas estadísticas fueron añadidas al perfil.\n• Ajustes menores en los textos.",
+
+		-- Congratulation messages
+		reached_level = "<d>¡Felicitaciones! Alcanzaste el nivel <vp>%s</vp>. (<t>%ss</t>)",
+		finished = "<d><o>%s</o> completó el parkour en <vp>%s</vp> segundos, <fc>¡felicitaciones!",
+		unlocked_power = "<ce><d>%s</d> desbloqueó el poder <vp>%s<ce>.",
+
+		-- Information messages
+		mod_apps = "<j>¡Las aplicaciones para moderador de parkour están abiertas! Usa este link: <rose>%s",
+		staff_power = "<r>El staff de Parkour <b>no tiene</b> ningún poder afuera de las salas de #parkour.",
+		donate = "<vp>¡Escribe <b>!donate</b> si te gustaría donar a este módulo!",
+		paused_events = "<cep><b>[¡Advertencia!]</b> <n>El módulo está entrando en estado crítico y está siendo pausado.",
+		resumed_events = "<n2>El módulo ha sido reanudado.",
+		welcome = "<n>¡Bienvenido a <t>#parkour</t>!",
+		module_update = "<r><b>[¡Advertencia!]</b> <n>El módulo se actualizará en <d>%02d:%02d</d>.",
+		leaderboard_loaded = "<j>La tabla de clasificación ha sido cargada. Presiona L para abrirla.",
+		kill_minutes = "<R>Tus poderes fueron desactivados por %s minutos.",
+		permbanned = "<r>Has sido baneado permanentemente de #parkour.",
+		tempbanned = "<r>Has sido baneado de #parkour por %s minutos.",
+		forum_topic = "<rose>Para más información del módulo visita este link: %s",
+		report = "<j>¿Quieres reportar a un jugador de parkour? <t><b>/c Parkour#8558 .report Usuario#0000</b></t>",
+
+		-- Easter Eggs
+		easter_egg_0  = "<ch>La cuenta atrás empezó...",
+		easter_egg_1  = "<ch>¡Faltan menos de 24 horas!",
+		easter_egg_2  = "<ch>¡Wow, viniste temprano! ¿Estás emocionado?",
+		easter_egg_3  = "<ch>Una sorpresa nos espera...",
+		easter_egg_4  = "<ch>¿Ya sabes lo que está a punto de pasar...?",
+		easter_egg_5  = "<ch>El reloj sigue contando...",
+		easter_egg_6  = "<ch>¡La sorpresa se acerca!",
+		easter_egg_7  = "<ch>La fiesta está por comenzar...",
+		easter_egg_8  = "<ch>Mira tu reloj, ¿ya es hora?",
+		easter_egg_9  = "<ch>Ten cuidado, el tiempo pasa rápido...",
+		easter_egg_10 = "<ch>Siéntate y relájate, ¡ya será mañana en poco tiempo!",
+		easter_egg_11 = "<ch>Iré a dormir temprano, ¡el tiempo pasará más rápido!",
+		easter_egg_12 = "<ch>La paciencia es una virtud",
+		easter_egg_13 = "<ch>https://youtu.be/9jK-NcRmVcw",
+		double_maps = "<bv>Los mapas cuentan doble el sábado (GMT+2) y todos los poderes están activados por la semana del cumpleaños de parkour!",
+		double_maps_start = "<rose>¡ES EL CUMPLEAÑOS DE PARKOUR! Los mapas cuentan doble y todos los poderes están disponibles. ¡Muchas gracias por jugar con nosotros!",
+		double_maps_end = "<rose>El cumpleaños de parkour acaba de terminar. ¡Muchas gracias por jugar con nosotros!",
+
+		-- Records
+		records_enabled = "<v>[#] <d>El modo de récords está activado en esta sala. ¡Las estadísticas no cuentan y los poderes están desactivados!\nPuedes encontrar más información sobre récords en <b>%s</b>",
+		records_admin = "<v>[#] <d>Eres un administrador de esta sala de récords. Puedes usar los comandos <b>!map</b>, <b>!setcp</b>, <b>!pw</b> y <b>!time</b>.",
+		records_completed = "<v>[#] <d>¡Completaste el mapa! Si te gustaría rehacerlo, escribe <b>!redo</b>.",
+		records_submit = "<v>[#] <d>¡Wow! Parece que completaste el mapa con el tiempo más rápido en la sala. Si te gustaría enviar tu record, escribe <b>!submit</b>.",
+		records_invalid_map = "<v>[#] <r>Parece que este mapa no está en la rotación de parkour... ¡No puedes enviar un récord en el!",
+		records_not_fastest = "<v>[#] <r>Parece que no eres el más rápido en la sala...",
+		records_already_submitted = "<v>[#] <r>¡Ya enviaste un récord para este mapa!",
+		records_submitted = "<v>[#] <d>Tu récord para el mapa <b>%s</b> ha sido enviado.",
+
+		-- Miscellaneous
+		afk_popup = "\n<p align='center'><font size='30'><bv><b>ESTÁS EN MODO AFK</b></bv>\nMUÉVETE PARA REAPARECER</font>\n\n<font size='30'><u><t>Recordatorios:</t></u></font>\n\n<font size='15'><r>¡Los jugadores con una línea roja sobre ellos no quieren ayuda!\n¡Trollear/bloquear a otros jugadores en parkour NO está permitido!<d>\n¡Únete a nuestro <cep><a href='event:discord'>servidor de discord</a></cep>!\n¿Quieres contribuir con código? Vé a nuestro <cep><a href='event:github'>repositorio de github</a></cep>\n¿Tienes un buen mapa para enviar? Envíalo a nuestro <cep><a href='event:map_submission'>hilo de presentaciones de mapas</a></cep>\n¡Checkea nuestro <cep><a href='event:forum'>hilo oficial</a></cep> para más información!\n¡Ayúdanos <cep><a href='event:donate'>donando!</a></cep>",
+		options = "<p align='center'><font size='20'>Opciones de Parkour</font></p>\n\nUsar teclado <b>QWERTY</b> (desactivar si usas <b>AZERTY</b>)\n\nUsar la tecla <b>M</b> como atajo para <b>/mort</b> (desactivar si usas <b>DEL</b>)\n\nMostrar tiempos de espera de tus poderes\n\nMostrar el botón de poderes\n\nMostrar el botón de ayuda\n\nMostrar mensajes al completar un mapa\n\nMostrar indicador para no recibir ayuda",
+		cooldown = "<v>[#] <r>Espera unos segundos antes de hacer eso de nuevo.",
+		power_options = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'>Teclado <b>QWERTY</b>" ..
+						 "\n\n<b>Esconder</b> cantidad de mapas" ..
+						 "\n\nUsar <b>tecla original</b>"),
+		unlock_power = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Completa <v>%s</v> mapas" ..
+						"<font size='5'>\n\n</font>para desbloquear" ..
+						"<font size='5'>\n\n</font><v>%s</v>"),
+		upgrade_power = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Completa <v>%s</v> mapas" ..
+						"<font size='5'>\n\n</font>para mejorar a" ..
+						"<font size='5'>\n\n</font><v>%s</v>"),
+		unlock_power_rank = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Posición <v>%s</v>" ..
+						"<font size='5'>\n\n</font>para desbloquear" ..
+						"<font size='5'>\n\n</font><v>%s</v>"),
+		upgrade_power_rank = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Posición <v>%s</v>" ..
+						"<font size='5'>\n\n</font>para mejorar a" ..
+						"<font size='5'>\n\n</font><v>%s</v>"),
+		maps_info = ("<p align='center'><font size='13' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
+					 "<font size='5'>\n\n</font>Mapas Completados"),
+		overall_info = ("<p align='center'><font size='13' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
+						"<font size='5'>\n\n</font>Posición General"),
+		weekly_info = ("<p align='center'><font size='13' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
+					   "<font size='5'>\n\n</font>Posición Semanal"),
+		badges = "<font size='14' face='Lucida Console,Liberation Mono,Courier New,Verdana'>Insignias (%s): <a href='event:_help:badge'><j>[?]</j></a>",
+		private_maps = "<bl>La cantidad de mapas de este jugador es privada. <a href='event:_help:private_maps'><j>[?]</j></a></bl>\n",
+		profile = ("<font size='12' face='Lucida Console,Liberation Mono,Courier New,Verdana'>%s%s %s\n\n" ..
+					"Posición general: <b><v>%s</v></b>\n\n" ..
+					"Posición semanal: <b><v>%s</v></b>\n\n%s"),
+		map_count = "Cantidad de mapas: <b><v>%s</v> / <a href='event:_help:yellow_maps'><j>%s</j></a> / <a href='event:_help:red_maps'><r>%s</r></a></b>",
+		title_count = ("<b><j>«!»</j></b> Mapas completados: <b><a href='event:_help:map_count_title'><v>%s</v></a></b>\n\n" ..
+					"<b><j>«!»</j></b> Checkpoints obtenidos: <b><a href='event:_help:checkpoint_count_title'><v>%s</v></a></b>"),
+		help_badge = "Las insignias son logros que un usuario puede obtener. Clickéalas para ver su descripción.",
+		help_private_maps = "¡A este jugador no le gusta compartir su cantidad de mapas! Podés esconder la tuya en tu perfil.",
+		help_yellow_maps = "Los mapas en amarillo fueron completados en esta semana.",
+		help_red_maps = "Los mapas en rojo fueron completados en la última hora.",
+		help_map_count_title = "¡Puedes obtener títulos al completar mapas de parkour!",
+		help_checkpoint_count_title = "¡Puedes obtener títulos al agarrar todos los checkpoints jugando parkour!",
+		help_badge_1 = "Este jugador fue un miembro del staff de parkour.",
+		help_badge_2 = "Este jugador está o estuvo en la página 1 del ranking general.",
+		help_badge_3 = "Este jugador está o estuvo en la página 2 del ranking general.",
+		help_badge_4 = "Este jugador está o estuvo en la página 3 del ranking general.",
+		help_badge_5 = "Este jugador está o estuvo en la página 4 del ranking general.",
+		help_badge_6 = "Este jugador está o estuvo en la página 5 del ranking general.",
+		help_badge_7 = "Este jugador estuvo en el podio cuando el ranking semanal se reinició.",
+		help_badge_8 = "Este jugador tiene un record de 30 mapas en una hora.",
+		help_badge_9 = "Este jugador tiene un record de 35 mapas en una hora.",
+		help_badge_10 = "Este jugador tiene un record de 40 mapas en una hora.",
+		help_badge_11 = "Este jugador tiene un record de 45 mapas en una hora.",
+		help_badge_12 = "Este jugador tiene un record de 50 mapas en una hora.",
+		help_badge_13 = "Este jugador tiene un record de 55 mapas en una hora.",
+		help_badge_14 = "Este jugador verificó su cuenta de discord en el servidor oficial de parkour (escribe <b>!discord</b>).",
+		help_badge_15 = "Este jugador tuvo el tiempo más rápido en 1 mapa.",
+		help_badge_16 = "Este jugador tuvo el tiempo más rápido en 5 mapas.",
+		help_badge_17 = "Este jugador tuvo el tiempo más rápido en 10 mapas.",
+		help_badge_18 = "Este jugador tuvo el tiempo más rápido en 15 mapas.",
+		help_badge_19 = "Este jugador tuvo el tiempo más rápido en 20 mapas.",
+		help_badge_20 = "Este jugador tuvo el tiempo más rápido en 25 mapas.",
+		help_badge_21 = "Este jugador tuvo el tiempo más rápido en 30 mapas.",
+		help_badge_22 = "Este jugador tuvo el tiempo más rápido en 35 mapas.",
+		help_badge_23 = "Este jugador tuvo el tiempo más rápido en 40 mapas.",
+		make_public = "hacer público",
+		make_private = "hacer privado",
+		moderators = "Moderadores",
+		mappers = "Mappers",
+		managers = "Líderes",
+		administrators = "Administradores",
+		close = "Cerrar",
+		cant_load_bot_profile = "<v>[#] <r>No puedes ver el perfil de este bot ya que #parkour lo usa internamente para funcionar.",
+		cant_load_profile = "<v>[#] <r>El jugador <b>%s</b> parece estar desconectado o no existe.",
+		like_map = "¿Te gusta este mapa?",
+		yes = "Sí",
+		no = "No",
+		idk = "No lo sé",
+		unknown = "Desconocido",
+		powers = "Poderes",
+		press = "<vp>Presiona %s",
+		click = "<vp>Haz clic",
+		ranking_pos = "Rank #%s",
+		completed_maps = "<p align='center'><BV><B>Mapas completados: %s</B></p></BV>",
+		leaderboard = "Tabla de clasificación",
+		position = "<V><p align=\"center\">Posición",
+		username = "<V><p align=\"center\">Jugador",
+		community = "<V><p align=\"center\">Comunidad",
+		completed = "<V><p align=\"center\">Mapas completados",
+		overall_lb = "General",
+		weekly_lb = "Semanal",
+		new_lang = "<v>[#] <d>Lenguaje cambiado a Español",
+
+		-- Power names
+		balloon = "Globo",
+		masterBalloon = "Globo Maestro",
+		bubble = "Burbuja",
+		fly = "Volar",
+		snowball = "Bola de nieve",
+		speed = "Velocidad",
+		teleport = "Teletransporte",
+		smallbox = "Caja pequeña",
+		cloud = "Nube",
+		rip = "Tumba",
+		choco = "Chocolate",
+		bigBox = "Caja grande",
+		trampoline = "Trampolín",
+		toilet = "Inodoro",
+		pig = "Cerdito",
+		sink = "Lavamanos",
+		bathtub = "Bañera",
+		campfire = "Fogata",
+		chair = "Silla",
+	}
+	--[[ End of file translations/parkour/es.lua ]]--
 	--[[ File translations/parkour/id.lua ]]--
 	translations.id = {
 	    name = "id",
@@ -2013,195 +3165,6 @@ local function initialize_parkour() -- so it uses less space after building
 	    chair = "Kursi",
 	}
 	--[[ End of file translations/parkour/id.lua ]]--
-	--[[ File translations/parkour/ru.lua ]]--
-	translations.ru = {
-		name = "ru",
-		fullname = "Русский",
-
-		-- Сообщения об ошибках
-		corrupt_map = "<r>Поврежденная карта. загрузите другую.",
-		corrupt_map_vanilla = "<r>[ОШИБКА] <n>Не удается получить информацию о карте.",
-		corrupt_map_mouse_start = "<r>[ОШИБКА] <n>Карта должна иметь начальную позицию (точку появления мыши).",
-		corrupt_map_needing_chair = "<r>[ОШИБКА] <n>На карте должно находиться кресло для окончания раунда.",
-		corrupt_map_missing_checkpoints = "<r>[ОШИБКА] <n>Карта должна иметь хотя бы один чекпоинт (желтый гвоздь).",
-		corrupt_data = "<r>К сожалению, ваши данные повреждены и были сброшены.",
-		min_players = "<r>Чтобы сохранить ваши данные, в комнате должно быть как минимум 4 уникальных игрока. <bl>[%s/%s]",
-		tribe_house = "<r>Данные не будут сохранены в комнате племени.",
-		invalid_syntax = "<r>Неверный синтаксис.",
-		code_error = "<r>Появилась ошибка: <bl>%s-%s-%s %s",
-		emergency_mode = "<r>Активировано аварийное отключение, новые игроки не смогут зайти. Пожалуйста, перейдите в другую комнату #pourour.",
-		leaderboard_not_loaded = "<r>Таблица лидеров еще не загружена. Подождите минуту.",
-		max_power_keys = "<v>[#] <r>You can only have at most %s powers in the same key.",
-
-		-- Help window
-		help = "Помощь",
-		staff = "Команда модераторов",
-		rules = "Правила",
-		contribute = "Содействие",
-		changelog = "Изменения",
-		help_help = "<p align = 'center'><font size = '14'>Добро пожаловать в <T>#parkour!</T></font></p>\n<font size = '12'><p align='center'><J>Ваша цель - собрать все чекпоинты, чтобы завершить карту.</J></p>\n\n<N>• Нажмите <O>O</O>, введите <O>!op</O> или нажмите на <O> шестеренку</O> чтобы открыть <T>меню настроек</T>.\n• Нажмите <O>P</O> или нажмите на <O>руку</O> в правом верхнем углу, чтобы открыть <T>меню со способностями</T>.\n• Нажмите <O>L</O> или введите <O>!lb</O> чтобы открыть <T>Список лидеров</T>.\n• Нажмите <O>M</O> или <O>Delete</O> чтобы не прописывать <T>/mort</T>.\n• Чтобы узнать больше о нашей <O>команде</O> и о <O>правилах паркура</O>, нажми на <T>Команда</T> и <T>Правила</T>.\n• Нажмите <a href='event:discord'><o>here</o></a> чтобы получить ссылку на приглашение в наш Дискорд канал. Нажмите <a href='event:map_submission'><o>here</o></a> чтобы получить ссылку на тему отправки карты.\n• Используйте клавиши <o>вверх</o> и <o>вниз</o> чтобы листать меню.\n\n<p align = 'center'><font size = '13'><T>Вкладки теперь открыты! Для получения более подробной информации, нажмите на вкладку <O>Содействие</O> !</T></font></p>",
-		help_staff = "<p align = 'center'><font size = '13'><r>ОБЯЗАННОСТИ: Команда Паркура НЕ команда Transformice и НЕ имеет никакой власти в самой игре, только внутри модуля.</r>\nКоманда Parkour обеспечивают исправную работу модуля с минимальными проблемами и всегда готова помочь игрокам в случае необходимости.</font></p>\nВы можете ввести <D>!staff</D> в чат, чтобы увидеть нашу команду.\n\n<font color = '#E7342A'>Администраторы:</font> Hесут ответственность за поддержку самого модуля, добавляя новые обновления и исправляя ошибки.\n\n<font color = '#D0A9F0'>Руководители команд:</font> Kонтролируют команды модераторов и картостроителей, следя за тем, чтобы они хорошо выполняли свою работу. Они также несут ответственность за набор новых членов в команду.\n\n<font color = '#FFAAAA'>Модераторы:</font> Hесут ответственность за соблюдение правил модуля и наказывают тех, кто не следует им.\n\n<font color = '#25C059'>Картостроители:</font> Oтвечают за просмотр, добавление и удаление карт в модуле, обеспечивая вам приятный игровой процесс.",
-		help_rules = "<font size = '13'><B><J>Все правила пользователя и условия Transformice также применяются к #parkour </J></B></font>\n\nЕсли вы обнаружили, что кто-то нарушает эти правила, напишите нашим модераторам. Если модераторов нет в сети, вы можете сообщить об этом на на нашем сервере в Discord\nПри составлении репорта, пожалуйста, укажите сервер, имя комнаты и имя игрока.\n• Пример: en-#parkour10 Blank#3495 троллинг\nДоказательства, такие как скриншоты, видео и гифки, полезны и ценны, но не обязательны.\n\n<font size = '11'>• <font color = '#ef1111'>читы, глюки или баги</font> не должны использоваться в комнатах #parkour\n• <font color = '#ef1111'>Фарм через VPN</font> считается <B>нарушением</B> и не допускается. <p align = 'center'><font color = '#cc2222' size = '12'><B>\nЛюбой, кто пойман за нарушение этих правил, будет немедленно забанен.</B></font></p>\n\n<font size = '12'>Transformice позволяет концепцию троллинга. Однако, <font color='#cc2222'><B>мы не допустим этого в паркуре.</B></font></font>\n\n<p align = 'center'><J>Троллинг - это когда игрок намеренно использует свои силы или инвентарь, чтобы помешать другим игрокам пройти/закончить карту.</J></p>\n• Троллинг ради мести <B>не является веской причиной,</B> для троллинга кого-либо и вы все равно будете наказаны.\n• Принудительная помощь игрокам, которые пытаются пройти карту самостоятельно и отказываюся от помощи, когда их об этом просят, также считается троллингом. \n• <J>Если игрок не хочет помогать или предпочитает играть в одиночку на карте, постарайтесь помочь другим игрокам</J>. Однако, если другой игрок нуждается в помощи на том же чекпоинте, что и соло игрок, вы можете помочь им [обоим].\n\nЕсли игрок пойман за троллингом, он будет наказан на временной основе. Обратите внимание, что повторный троллинг приведет к более длительным и суровым наказаниям.",
-		help_contribute = "<font size='14'>\n<p align='center'>Команда управления паркуром предпочитает открытый исходный код, потому что он <t>помогает сообществу</t>. Вы можете <o>посмотреть</o> и <o>улучшить</o> исходный код на <o><u><a href='event:github'>GitHub</a></u></o>.\nПоддержание модуля<t>строго добровольно</t>, так что любая помощь в отношении <t>code</t>, <t>баг репортов</t>, <t>предложений</t> and <t>созданию карт</t> is always <u>приветствуется и ценится</u>.\nВы можете <vp>оставлять жалобу</vp> и <vp>предлагать улучшения</vp> в нашем <o><u><a href='event:discord'>Дискорде</a></u></o> и/или в <o><u><a href='event:github'>GitHub</a></u></o>.\nВы можете <vp>отправить свои карты</vp> на нашем <o><u><a href='event:map_submission'>форуме</a></u></o>.\n\nПоддержание паркура не дорогое, но и не бесплатное. Мы будем рады, если вы поможете нам <t>любой суммой</t> <o><u><a href='event:donate'>here</a></u></o>.\n<u>Все пожертвования пойдут на улучшение модуля.</u></p>",
-		help_changelog = "<font size='13'><p align='center'><o>Version 2.10.0 - 17/04/2021</o></p>\n\n<font size='11'>• <font size='13'><b><j>THREE</J></b> brand new Transformice titles that can only be unlocked by playing <font color='#1A7EC9'><b>#parkour</b></font>!</font>\n• Two new statuses added to the profile.\n• Minor text adjustments.",
-
-		-- Congratulation messages
-		reached_level = "<d>Поздравляем! Вы достигли уровня <vp>%s</vp>. (<t>%ss</t>)",
-		finished = "<d><o>%s</o> завершил паркур за <vp>%s</vp> секунд, <fc>поздравляем!",
-		unlocked_power = "<ce><d>%s</d> разблокировал способность <vp>%s</vp>.",
-
-		-- Information messages
-		mod_apps = "<j>Приложения паркура модератора теперь открыты! Используйте эту ссылку: <rose>%s",
-		staff_power = "<r>Команда паркура <b>не</b> имеет власти вне #parkour комнат.",
-		donate = "<vp>Введите <b>!donate</b>, если хотите пожертвовать на этот модуль!",
-		paused_events = "<cep><b>[Предупреждение!]</b> <n> Модуль достиг критического предела и сейчас временно остановлен.",
-		resumed_events = "<n2>Модуль был возобновлен.",
-		welcome = "<n>Добро пожаловать в<t>#parkour</t>!",
-		module_update = "<r><b>[Предупреждение!]</b> <n>Модуль будет обновлен в <d>%02d:%02d</d>.",
-		leaderboard_loaded = "<j>Таблица лидеров была загружена. Нажмите L, чтобы открыть ее.",
-		kill_minutes = "<R>Ваши способности отключены на %s минут.",
-		permbanned = "<r>Вы были навсегда забанены в #parkour.",
-		tempbanned = "<r>Вы были забанены в #parkour на %s минут.",
-		forum_topic = "<rose>Для получения дополнительной информации о модуле посетите эту ссылку: %s",
-		report = "<j>Хотите пожаловаться на игрока? <t><b>/c Parkour#8558 .report Никнейм#0000</b></t>",
-
-		-- Easter Eggs
-		easter_egg_0  = "<ch>Итак, наступает обратный отсчет...",
-		easter_egg_1  = "<ch>Остается меньше, чем 24 часа!",
-		easter_egg_2  = "<ch>Вау, ты пришел очень рано! Ты слишком взволнован?",
-		easter_egg_3  = "<ch>Ожидается сюрприз...",
-		easter_egg_4  = "<ch>Ты знаешь о том, что должно произойти...?",
-		easter_egg_5  = "<ch>Часы продолжают тикать...",
-		easter_egg_6  = "<ch>Сюрприз близок!",
-		easter_egg_7  = "<ch>Вечеринка скоро начнется...",
-		easter_egg_8  = "<ch>Взгляни на часы, не пора ли?",
-		easter_egg_9  = "<ch>Будь осторожен, время идет...",
-		easter_egg_10 = "<ch>Просто сядь и расслабься, это будет завтра в кратчайшие сроки!",
-		easter_egg_11 = "<ch>Давай ляжем спать пораньше, это сделает время быстрее!",
-		easter_egg_12 = "<ch>Терпение это добродетель",
-		easter_egg_13 = "<ch>https://youtu.be/9jK-NcRmVcw",
-		double_maps = "<bv>Удвоенные карты и все силы доступы на неделе рождения паркура!",
-		double_maps_start = "<rose>ЭТО НЕДЕЛЯ РОЖДЕНИЯ ПАРКУРА! Удвоенные карты и все силы были активированы. Спасибо за то, что играешь с нами!",
-		double_maps_end = "<rose>Неделя рождения паркура закончилась. Спасибо за то, что играешь с нами!",
-
-		-- Records
-		records_enabled = "<v>[#] <d>RВ этой комнате включен режим рекордов. Статистика не учитывается, а умения отключены!\nВы можете найти больше информации в <b>%s</b>",
-		records_admin = "<v>[#] <d>Вы администратор этой комнаты. Вы можете использовать команды <b>!map</b>, <b>!setcp</b>, <b>!pw</b> и <b>!time</b>.",
-		records_completed = "<v>[#] <d>Вы прошли карту! Если вы хотите сделать это заново, введите <b>!redo</b>.",
-		records_submit = "<v>[#] <d>Вот Это Да! Похоже, ты быстрее всех прошел карту. Если хочешь поделиться своим рекордом, введи  <b>!submit</b>.",
-		records_invalid_map = "<v>[#] <r>Похоже, эта карта не в ротации паркура ... Вы не можете сохранить рекорд для нее!",
-		records_not_fastest = "<v>[#] <r>Кажется, ты не самый быстрый игрок в комнате ...",
-		records_already_submitted = "<v>[#] <r>Вы уже отправили свой рекорд для этой карты!",
-		records_submitted = "<v>[#] <d>Ваш рекорд на этой карте <b>%s</b> был сохранен.",
-
-		-- Miscellaneous
-		afk_popup = "\n<p align='center'><font size='30'><bv><b>YOU'RE ON AFK MODE</b></bv>\nMOVE TO RESPAWN</font>\n\n<font size='30'><u><t>Reminders:</t></u></font>\n\n<font size='15'><r>Players with a red line over them don't want help!\nTrolling/blocking other players in parkour is NOT allowed!<d>\nJoin our <cep><a href='event:discord'>discord server</a></cep>!\nWant to contribute with code? See our <cep><a href='event:github'>github repository</a></cep>\nDo you have a good map to submit? Post it in our <cep><a href='event:map_submission'>map submission topic</a></cep>\nCheck our <cep><a href='event:forum'>official topic</a></cep> for more information!\nSupport us by <cep><a href='event:donate'>donating!</a></cep>",
-		options = "<p align='center'><font size='20'>Параметры Паркура</font></p>\n\nИспользуйте <b>QWERTY</b> на клавиатуре (отключить if <b>AZERTY</b>)\n\nИспользуйте <b>M</b> горячую клавишу <b>/mort</b> (отключить <b>DEL</b>)\n\nПоказать ваше время перезарядки\n\nПоказать кнопку способностей\n\nПоказать кнопку помощь\n\nПоказать объявление о завершении карты\n\nПоказать символ помощь не нужна",
-		cooldown = "<v>[#] <r>Подождите несколько минут, чтобы повторить действие.",
-		power_options = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><b>QWERTY</b> клавиатура" ..
-						 "\n\n<b>Hide</b> map count" ..
-						 "\n\nUse <b>default key</b>"),
-		unlock_power = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Пройденные <v>%s</v> карты" ..
-						"<font size='5'>\n\n</font>разблокированы" ..
-						"<font size='5'>\n\n</font><v>%s</v>"),
-		upgrade_power = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Пройденные <v>%s</v> карты" ..
-						"<font size='5'>\n\n</font>обновлены" ..
-						"<font size='5'>\n\n</font><v>%s</v>"),
-		unlock_power_rank = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Ранг <v>%s</v>" ..
-						"<font size='5'>\n\n</font>разбокирован" ..
-						"<font size='5'>\n\n</font><v>%s</v>"),
-		upgrade_power_rank = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Ранг <v>%s</v>" ..
-						"<font size='5'>\n\n</font>обновлен" ..
-						"<font size='5'>\n\n</font><v>%s</v>"),
-		maps_info = ("<p align='center'><font size='13' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
-					 "<font size='5'>\n\n</font>Пройденые карты"),
-		overall_info = ("<p align='center'><font size='13' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
-						"<font size='5'>\n\n</font>Общая таблица лидеров"),
-		weekly_info = ("<p align='center'><font size='13' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
-					   "<font size='5'>\n\n</font>Еженедельная таблица лидеров"),
-		badges = "<font size='14' face='Lucida Console,Liberation Mono,Courier New,Verdana'>Badges (%s): <a href='event:_help:badge'><j>[?]</j></a>",
-		private_maps = "<bl>Количество карт этого игрока является частным.<a href='event:_help:private_maps'><j>[?]</j></a></bl>\n",
-		profile = ("<font size='12' face='Lucida Console,Liberation Mono,Courier New,Verdana'>%s%s %s\n\n" ..
-					"Общая таблица лидеров: <b><v>%s</v></b>\n\n" ..
-					"Еженедельначя таблица лидеров: <b><v>%s</v></b>\n\n%s"),
-		map_count = "Количество карт: <b><v>%s</v> / <a href='event:_help:yellow_maps'><j>%s</j></a> / <a href='event:_help:red_maps'><r>%s</r></a></b>",
-		help_badge = "Значки - это достижение, которое может получить игрок. Нажмите на них, чтобы увидеть их описание.",
-		help_private_maps = "Этот игрок не любит публично публиковать количество своих карт! Вы также можете скрыть их в своем профиле.",
-		help_yellow_maps = "Желтым цветом обозначены карты, завершенные на этой неделе.",
-		help_red_maps = "Карты красного цвета - это карты, завершенные за последний час.",
-		help_badge_1 = "Этот игрок в прошлом был сотрудником паркура.",
-		help_badge_2 = "Этот игрок находится или был на странице 1 общей таблицы лидеров.",
-		help_badge_3 = "Этот игрок находится или был на странице 2 общей таблицы лидеров.",
-		help_badge_4 = "Этот игрок находится или был на странице 3 общей таблицы лидеров.",
-		help_badge_5 = "Этот игрок находится или был на странице 4 общей таблицы лидеров.",
-		help_badge_6 = "Этот игрок находится или был на странице 5 общей таблицы лидеров.",
-		help_badge_7 = "Этот игрок был в еженедельной таблицы лидеров.",
-		help_badge_8 = "У этого игрока рекорд - 30 карт в час.",
-		help_badge_9 = "У этого игрока рекорд - 35 карт в час.",
-		help_badge_10 = "У этого игрока рекорд - 40 карт в час.",
-		help_badge_11 = "У этого игрока рекорд - 45 карт в час.",
-		help_badge_12 = "У этого игрока рекорд - 50 карт в час.",
-		help_badge_13 = "У этого игрока рекорд - 55 карт в час.",
-		help_badge_14 = "Этот пользователь подтвердил свою учетную запись на официальном канале сервера паркура (нажмите <b>!discord</b>).",
-		help_badge_15 = "Этот игрок показал лучшее время на 1 карте.",
-		help_badge_16 = "Этот игрок показал лучшее время на 5 картах.",
-		help_badge_17 = "Этот игрок показал лучшее время на 10 картах.",
-		help_badge_18 = "Этот игрок показал лучшее время на 15 картах.",
-		help_badge_19 = "Этот игрок показал лучшее время на 20 картах.",
-		help_badge_20 = "Этот игрок показал лучшее время на 25 картах.",
-		help_badge_21 = "Этот игрок показал лучшее время на 30 картах.",
-		help_badge_22 = "Этот игрок показал лучшее время на 35 картах.",
-		help_badge_23 = "Этот игрок показал лучшее время на 40 картах.",
-		make_public = "сделать публичным",
-		make_private = "сделать приватым",
-		moderators = "Модераторы",
-		mappers = "Maпперы",
-		managers = "Mенеджеры",
-		administrators = "Администрация",
-		close = "Закрыть",
-		cant_load_bot_profile = "<v>[#] <r>You can't see this bot's profile since #parkour uses it internally to work properly.",
-		cant_load_profile = "<v>[#] <r>The player <b>%s</b> seems to be offline or does not exist.",
-		like_map = "Do you like this map?",
-		yes = "Yes",
-		no = "No",
-		idk = "I don't know",
-		unknown = "Неизвестно",
-		powers = "Способности",
-		press = "<vp>Нажмите %s",
-		click = "<vp>Щелчок левой кнопкой мыши",
-		ranking_pos = "Рейтинг #%s",
-		completed_maps = "<p align='center'><BV><B>Пройденные карты: %s</B></p></BV>",
-		leaderboard = "Таблица лидеров",
-		position = "<V><p align=\"center\">Должность",
-		username = "<V><p align=\"center\">Имя пользователя",
-		community = "<V><p align=\"center\">Сообщество",
-		completed = "<V><p align=\"center\">Пройденные карты",
-		overall_lb = "В целом",
-		weekly_lb = "Еженедельно",
-		new_lang = "<v>[#] <d>Язык установлен на Русский",
-
-		-- Power names
-		balloon = "Шар",
-		masterBalloon = "Мастер шар",
-		bubble = "Пузырь",
-		fly = "Полет",
-		snowball = "Снежок",
-		speed = "Скорость",
-		teleport = "Телепорт",
-		smallbox = "Маленький ящик",
-		cloud = "Облако",
-		rip = "Могила",
-		choco = "Шоколадная палка",
-		bigBox = "Большая коробка",
-		trampoline = "Батут",
-		toilet = "Туалет",
-		pig = "Свинья",
-		sink = "тонуть",
-		bathtub = "Ванна",
-		campfire = "Костёр",
-		chair = "Стул",
-	}
-	--[[ End of file translations/parkour/ru.lua ]]--
 	--[[ File translations/parkour/ro.lua ]]--
 	translations.ro = {
 		name = "ro",
@@ -2395,776 +3358,6 @@ local function initialize_parkour() -- so it uses less space after building
 		chair = "Scaun",
 	}
 	--[[ End of file translations/parkour/ro.lua ]]--
-	--[[ File translations/parkour/cn.lua ]]--
-	translations.cn = {
-		name = "cn",
-		fullname = "中文",
-
-		-- Error messages
-		corrupt_map = "<r>地圖崩壞。正在載入另一張。",
-		corrupt_map_vanilla = "<r>[錯誤] <n>無法取得此地圖的資訊。",
-		corrupt_map_mouse_start = "<r>[錯誤] <n>此地圖需要有起始位置 (小鼠出生點)。",
-		corrupt_map_needing_chair = "<r>[錯誤] <n>地圖需要包括終點椅子。",
-		corrupt_map_missing_checkpoints = "<r>[錯誤] <n>地圖需要有最少一個重生點 (黃色釘子)。",
-		corrupt_data = "<r>不幸地, 你的資料崩壞了而被重置了。",
-		min_players = "<r>房間裡需要至少4名玩家才可以保存資料。 <bl>[%s/%s]",
-		tribe_house = "<r>在部落之家遊玩的資料不會被儲存。",
-		invalid_syntax = "<r>無效的格式。",
-		code_error = "<r>發生了錯誤: <bl>%s-%s-%s %s",
-		emergency_mode = "<r>正在啟動緊急終止模式, 新玩家無法加入遊戲。請前往另一個　#parkour 房間。",
-		leaderboard_not_loaded = "<r>排行榜沒被加載。請稍後片刻。",
-		max_power_keys = "<v>[#] <r>你只可以在同一個按鍵使用最多 %s 個能力。",
-
-		-- Help window
-		help = "幫助",
-		staff = "職員",
-		rules = "規則",
-		contribute = "貢獻",
-		changelog = "新聞",
-		help_help = "<p align = 'center'><font size = '14'>歡迎來到 <T>#parkour!</T></font></p>\n<font size = '12'><p align='center'><J>你的目標是到達所有重生點直到完成地圖。</J></p>\n\n<N>• 按 <O>O</O>鍵, 輸入 <O>!op</O> 或是點擊右上方的 <O>齒輪</O> 來開啟 <T>選項目錄</T>。\n• 按 <O>P</O> 鍵或是點擊右上方的 <O>拳頭標誌</O> 來開啟 <T>能力目錄</T>。\n• 按 <O>L</O> 鍵或是輸入 <O>!lb</O> 來開啟 <T>排行榜</T>。\n• 按 <O>M</O> 鍵或是 <O>刪除</O> 鍵來 <T>自殺</T>, 你可以在 <J>選項</J> 目錄中激活按鍵。\n• 要知道更多關於我們 <O>職員</O> 的資訊以及 <O>parkour 的規則</O>, 可點擊 <T>職員</T> 及 <T>規則</T> 的分頁查看。\n• 點擊 <a href='event:discord'><o>這裡</o></a> 來取得 discord 邀請連結及 <a href='event:map_submission'><o>這裡</o></a> 來得到提交地圖的論壇連結。\n• 當你想滾動頁面可使用 <o>上</o> 鍵及 <o>下</o> 鍵。\n\n<p align = 'center'><font size = '13'><T>貢獻現在是開放的! 點擊 <O>貢獻</O> 分頁來了解更多!</T></font></p>",
-		help_staff = "<p align = 'center'><font size = '13'><r>免責聲明: Parkour 的職員並不是 Transformice 職員而且在遊戲裡沒有任何權力, 只負責這小遊戲的規管。</r>\nParkour 職員確保小遊戲減少錯誤而運作順暢, 而且可以在有需要時協助玩家。</font></p>\n你可以在聊天框輸入 <D>!staff</D> 來查看職員列表。\n\n<font color = '#E7342A'>工作人員:</font> 他們負責透過更新及修復滴漏洞來維護小遊戲。\n\n<font color = '#D0A9F0'>小隊主管:</font> 他們會觀察管理團隊及地圖團隊, 確保他們在工作上的表現。他們也負責招募新成員加入職員團隊中。\n\n<font color = '#FFAAAA'>管理員:</font> 他們負責執行小遊戲裡的規則以及處分違反規則的玩家。\n\n<font color = '#25C059'>地圖管理員:</font> 他們負責審核, 新增, 以及移除小遊戲裡的地圖來確保你可以享受遊戲過程。",
-		help_rules = "<font size = '13'><B><J>所有適用於 Transformice 的條款及細則也適用於 #parkour</J></B></font>\n\n如果你發現任何玩家違反這些規則, 可以在遊戲中私聊 parkour 的管理員。如果沒有管理員在線, 你可以在 discord 伺服器中舉報事件。\n當你舉報的時候, 請提供你所在的伺服器, 房間名稱, 以及玩家名稱。\n• 例如: en-#parkour10 Blank#3495 trolling\n證明, 例如是截圖, 錄象以及gif圖能有效協助舉報, 但不是一定需要的。\n\n<font size = '11'>• 任何 <font color = '#ef1111'>外掛, 瑕疵或漏洞</font> 是不能在 #parkour 房間中使用\n• <font color = '#ef1111'>VPN 刷數據</font> 會被當作 <B>利用漏洞</B> 而不被允許的。 <p align = 'center'><font color = '#cc2222' size = '12'><B>\n任何人被抓到違反規則會被即時封禁。</B></font></p>\n\n<font size = '12'>Transformice 允許搗蛋行為。但是, <font color='#cc2222'><B>我們不允許在 parkour 的搗蛋行為。</B></font></font>\n\n<p align = 'center'><J>惡作劇是指一個玩家有意圖地使用能力或消耗品來阻止其他玩家完成地圖。</j></p>\n• 復仇性的搗蛋行為 <B>並不是一個合理解釋</B> 來搗亂別人而因此你也會被處分。\n• 強迫想自理的玩家接受協助而當他說不用之後仍舊沒有停止此行為也會被視作搗蛋。\n• <J>如果一個玩家不想被協助或是想自理通關, 請你盡力協助其他玩家。</J> 但是如果有另外的玩家需要協助而剛好跟自理玩家在同一個重生點, 你可以協助他們 [兩人]。\n\n如果玩家惡作劇被抓, 會被處分基於時間的懲罰。重覆的搗蛋行為會引至更長及更嚴重的處分。",
-		help_contribute = "<font size='14'>\n<p align='center'>Parkour 管理團隊喜愛開放原始碼是因為它能夠<t>協助社群</t>。 你可以在 <o><u><a href='event:github'>GitHub</a></u></o> <o>查看</o> 以及 <o>修改</o> 原始碼。\n\n維護這個小遊戲是 <t>義務性質</t>, 所以任何在 <t>編程</t>, <t>漏洞回饋</t>, <t>建議</t> 及 <t>地圖創作</t> 上提供的幫助將會是十分 <u>歡迎而且非常感激</u>。\n你可以在 <o><u><a href='event:discord'>Discord</a></u></o> 及/或 <o><u><a href='event:github'>GitHub</a></u></o> <vp>匯報漏洞</vp> 和 <vp>提供意見</vp>。\n你可以在我們的 <o><u><a href='event:map_submission'>論壇帖子</a></u></o> 中 <vp>提交你的地圖</vp>。\n\n維護 Parkour 不是很花費, 但也不完全是免費。我們希望你能夠在 <o><u><a href='event:donate'>這裡</a></u></o> <t>捐贈任何金額</t> 來支持我們。\n<u>所有捐款會用來改善這個小遊戲。</u></p>",
-		help_changelog = "<font size='13'><p align='center'><o>Version 2.10.0 - 17/04/2021</o></p>\n\n<font size='11'>• <font size='13'><b><j>三個</J></b> 全新的 Transformice 稱號只可以在<font color='#1A7EC9'><b>#parkour</b></font>遊玩而解鎖!</font>\n• 在個資中加入兩項新的資訊。\n• 調整細微文字格式。",
-
-		-- Congratulation messages
-		reached_level = "<d>恭喜! 你到達了第 <vp>%s</vp> 個重生點。 (<t>%ss</t>)",
-		finished = "<d><o>%s</o> 在 <vp>%s</vp> 秒內完成了地圖, <fc>恭喜!",
-		unlocked_power = "<ce><d>%s</d> 解鎖了 <vp>%s</vp> 能力。",
-
-		-- Information messages
-		staff_power = "<r>Parkour 職員 <b>不會</b> 擁有任何在 #parkour 房間以外的權力。",
-		donate = "<vp>如果你想為此小遊戲捐款，請輸入<b>!donate</b>！",
-		paused_events = "<cep><b>[警告!]</b> <n>小遊戲已達到最高流量限制而被暫停了。",
-		resumed_events = "<n2>小遊戲已繼續啟用。",
-		welcome = "<n>歡迎來到 <t>#parkour</t>!",
-		module_update = "<r><b>[警告!]</b> <n>小遊戲將會在 <d>%02d:%02d</d> 後更新。",
-		leaderboard_loaded = "<j>排行榜已載入。請按 L 鍵打開它。",
-		kill_minutes = "<R>你的能力已經在 %s 分鐘內暫時取消了。",
-		permbanned = "<r>你已經在 #parkour 被永久封禁。",
-		tempbanned = "<r>你已經在 #parkour 被封禁了 %s 分鐘。",
-		forum_topic = "<rose>更多關於這個小遊戲的資訊可以查看: %s",
-		report = "<j>想舉報玩家? <t><b>/c Parkour#8558 .report 玩家名字#0000</b></t>",
-
-		-- Easter Eggs
-		easter_egg_0  = "<ch>所以要開始倒數了...",
-		easter_egg_1  = "<ch>剩下時間少於 24 小時!",
-		easter_egg_2  = "<ch>哇, 你挺早的! 你是不是太興奮了?",
-		easter_egg_3  = "<ch>一個驚喜在等待你...",
-		easter_egg_4  = "<ch>你知道接下來將會發生什麼...?",
-		easter_egg_5  = "<ch>時間滴答滴答在過著...",
-		easter_egg_6  = "<ch>驚喜快要到了!",
-		easter_egg_7  = "<ch>派對很快要開始...",
-		easter_egg_8  = "<ch>查看你的時鐘, 是時候了嗎?",
-		easter_egg_9  = "<ch>注意, 時間在一直走...",
-		easter_egg_10 = "<ch>坐下來放鬆一下, 馬上就到明天了!",
-		easter_egg_11 = "<ch>一起早點到床上, 會使時間過得更快!",
-		easter_egg_12 = "<ch>最重要是耐心",
-		easter_egg_13 = "<ch>https://youtu.be/9jK-NcRmVcw",
-		double_maps = "<bv>雙倍地圖計算將會在星期六 (GMT+2) 開始, 而且所有能力都可以在這 parkour 生日週使用!",
-		double_maps_start = "<rose>這週是 PARKOUR 的生日! 雙倍地圖計算而且所有能力都已被激活使用。感謝跟我們一起遊玩!",
-		double_maps_end = "<rose>Parkour 的生日週已完結。感謝各位的遊玩!",
-
-		-- Records
-		records_enabled = "<v>[#] <d>記錄模式已在這房間啟用。數據不會被記錄而且不能使用能力!\n你可以在這裡查看更多關於記錄模式的資訊: <b>%s</b>",
-		records_admin = "<v>[#] <d>你是這房間的管理員。你可以使用以下指令 <b>!map</b>, <b>!setcp</b>, <b>!pw</b> and <b>!time</b>。",
-		records_completed = "<v>[#] <d>你已經完成了地圖! 如果你想重新嘗試, 可輸入 <b>!redo</b>。",
-		records_submit = "<v>[#] <d>哇! 看來你達成了房間裡最快的通關時間。如果你希望提交你的記錄, 可輸入 <b>!submit</b>。",
-		records_invalid_map = "<v>[#] <r>看來這張地圖並不在 parkour 的循環裡... 你不能提交這地圖的記錄!",
-		records_not_fastest = "<v>[#] <r>看來你並不是房間裡最快通關的玩家...",
-		records_already_submitted = "<v>[#] <r>你已經提交了這地圖的通關時間記錄!",
-		records_submitted = "<v>[#] <d>你在地圖 <b>%s</b> 的時間記錄已被提交。",
-
-		-- Miscellaneous
-		mod_apps = "<j>Parkour 管理員申請現正開放! 請查看這連結: <rose>%s",
-		afk_popup = "\n<p align='center'><font size='30'><bv><b>你正在掛機模式</b></bv>\n隨意移動來復活</font>\n\n<font size='30'><u><t>提示:</t></u></font>\n\n<font size='15'><r>玩家頭上的紅線表示他們不想被協助!\n在parkour惡作劇/阻礙其他玩家通關是不被允許的!<d>\n加入我們的 <cep><a href='event:discord'>discord 伺服器</a></cep>!\n想在編程上貢獻? 查看 <cep><a href='event:github'>github 編程庫</a></cep> 吧。\n你有好的地圖想提交嗎? 在我們的 <cep><ahref='event:map_submission'>地圖提交帖子</a></cep> 上留言吧。\n查看我們的 <cep><a href='event:forum'>官方帖子</a></cep> 來得到更多資訊!\n透過 <cep><a href='event:donate'>捐款</a></cep> 支持我們吧!",
-		options = "<p align='center'><font size='20'>Parkour 選項</font></p>\n\n使用 <b>QWERTY</b> 鍵盤 (使用<b>AZERTY</b>請關閉此項)\n\n使用快捷鍵 <b>M</b> 來 <b>自殺</b> (使用<b>DEL</b>請關閉此項)\n\n顯示你的能力緩衝時間\n\n顯示能力選項按鈕\n\n顯示幫助按鈕\n\n顯示完成地圖的公告\n\n顯示不用被幫助的標示",
-		cooldown = "<v>[#] <r>請等候幾秒再重新嘗試。",
-		power_options = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><b>QWERTY</b> 鍵盤" ..
-						 "\n\n<b>隱藏</b> 地圖通過數" ..
-						 "\n\n使用 <b>預設鍵</b>"),
-		unlock_power = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>完成 <v>%s</v> 張地圖" ..
-						"<font size='5'>\n\n</font>來解鎖" ..
-						"<font size='5'>\n\n</font><v>%s</v>"),
-		upgrade_power = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>完成 <v>%s</v> 張地圖" ..
-						"<font size='5'>\n\n</font>來升級到" ..
-						"<font size='5'>\n\n</font><v>%s</v>"),
-		unlock_power_rank = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>階級 <v>%s</v>" ..
-						"<font size='5'>\n\n</font>來解鎖" ..
-						"<font size='5'>\n\n</font><v>%s</v>"),
-		upgrade_power_rank = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>階級 <v>%s</v>" ..
-						"<font size='5'>\n\n</font>來升級到" ..
-						"<font size='5'>\n\n</font><v>%s</v>"),
-		maps_info = ("<p align='center'><font size='13' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
-					 "<font size='5'>\n\n</font>完成地圖數"),
-		overall_info = ("<p align='center'><font size='13' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
-						"<font size='5'>\n\n</font>整體排行榜"),
-		weekly_info = ("<p align='center'><font size='13' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
-					   "<font size='5'>\n\n</font>每周排行榜"),
-		badges = "<font size='14' face='Lucida Console,Liberation Mono,Courier New,Verdana'>徽章 (%s): <a href='event:_help:badge'><j>[?]</j></a>",
-		private_maps = "<bl>玩家的地圖通過數已設定為私人。 <a href='event:_help:private_maps'><j>[?]</j></a></bl>\n",
-		profile = ("<font size='12' face='Lucida Console,Liberation Mono,Courier New,Verdana'>%s%s %s\n\n" ..
-					"整體排行榜名次: <b><v>%s</v></b>\n\n" ..
-					"每周排行榜名次: <b><v>%s</v></b>\n\n%s"),
-		map_count = "地圖通過數: <b><v>%s</v> / <a href='event:_help:yellow_maps'><j>%s</j></a> / <a href='event:_help:red_maps'><r>%s</r></a></b>",
-		title_count = ("<b><j>«!»</j></b> 完成地圖次數: <b><a href='event:_help:map_count_title'><v>%s</v></a></b>\n\n" ..
-					"<b><j>«!»</j></b> 到達重生點次數: <b><a href='event:_help:checkpoint_count_title'><v>%s</v></a></b>"),
-		help_badge = "徽章是玩家可以得到的成就。點擊它們查看介紹。",
-		help_private_maps = "這玩家不想公開分享他的地圖通過數! 你也可以在個人資料中設定隱藏。",
-		help_yellow_maps = "黃色標示的地圖是這周完成了的地圖。",
-		help_red_maps = "紅色標示的地圖是過去一小時內完成了的地圖。",
-		help_map_count_title = "你可以透過完成 parkour 地圖獲得 <b>Transformice</b> 稱號!",
-		help_checkpoint_count_title = "你可以透過到達 parkour 裡所有重生點獲得  <b>Transformice</b> 稱號!",
-		help_badge_1 = "這玩家曾經是parkour 的職員。",
-		help_badge_2 = "這玩家是或曾經達成在整體排行榜的第 1 頁上。",
-		help_badge_3 = "這玩家是或曾經達成在整體排行榜的第 2 頁以上。",
-		help_badge_4 = "這玩家是或曾經達成在整體排行榜的第 3 頁以上。",
-		help_badge_5 = "這玩家是或曾經達成在整體排行榜的第 4 頁以上。",
-		help_badge_6 = "這玩家是或曾經達成在整體排行榜的第 5 頁以上。",
-		help_badge_7 = "這玩家曾經在每周排行榜中得到前三名。",
-		help_badge_8 = "這玩家達成了在一小時內通過 30 張地圖的記錄。",
-		help_badge_9 = "這玩家達成了在一小時內通過 35 張地圖的記錄。",
-		help_badge_10 = "這玩家達成了在一小時內通過 40 張地圖的記錄。",
-		help_badge_11 = "這玩家達成了在一小時內通過 45 張地圖的記錄。",
-		help_badge_12 = "這玩家達成了在一小時內通過 50 張地圖的記錄。",
-		help_badge_13 = "這玩家達成了在一小時內通過 55 張地圖的記錄。",
-		help_badge_14 = "這玩家已經在官方 parkour discord 伺服器上驗證了帳戶 (輸入 <b>!discord</b>)。",
-		help_badge_15 = "這玩家以最快的時間完成了 1 張地圖。",
-		help_badge_16 = "這玩家以最快的時間完成了 5 張地圖。",
-		help_badge_17 = "這玩家以最快的時間完成了 10 張地圖。",
-		help_badge_18 = "這玩家以最快的時間完成了 15 張地圖。",
-		help_badge_19 = "這玩家以最快的時間完成了 20 張地圖。",
-		help_badge_20 = "這玩家以最快的時間完成了 25 張地圖。",
-		help_badge_21 = "這玩家以最快的時間完成了 30 張地圖。",
-		help_badge_22 = "這玩家以最快的時間完成了 35 張地圖。",
-		help_badge_23 = "這玩家以最快的時間完成了 40 張地圖。",
-		make_public = "設定為公開",
-		make_private = "設定為私人",
-		moderators = "管理員",
-		mappers = "地圖管理員",
-		managers = "小隊主管",
-		administrators = "工作人員",
-		close = "關閉",
-		cant_load_bot_profile = "<v>[#] <r>你不能查看這機器人的個人資料因為 #parkour 利用它來進行內部運作。",
-		cant_load_profile = "<v>[#] <r>玩家 <b>%s</b> 看來不在線或是不存在。",
-		like_map = "你喜歡這地圖嗎?",
-		yes = "是",
-		no = "不是",
-		idk = "我不知道",
-		unknown = "不明物",
-		powers = "能力",
-		press = "<vp>按 %s",
-		click = "<vp>左鍵點擊",
-		ranking_pos = "排名 #%s",
-		completed_maps = "<p align='center'><BV><B>完成的地圖數: %s</B></p></BV>",
-		leaderboard = "排行榜",
-		position = "<V><p align=\"center\">位置",
-		username = "<V><p align=\"center\">用戶名",
-		community = "<V><p align=\"center\">社區",
-		completed = "<V><p align=\"center\">完成地圖數",
-		overall_lb = "主要排名",
-		weekly_lb = "每周排名",
-		new_lang = "<v>[#] <d>語言已被更換成 繁體中文",
-
-		-- Power names
-		balloon = "氣球",
-		masterBalloon = "進階氣球",
-		bubble = "泡泡",
-		fly = "飛行",
-		snowball = "雪球",
-		speed = "加速",
-		teleport = "傳送",
-		smallbox = "小箱子",
-		cloud = "白雲",
-		rip = "墓碑",
-		choco = "巧克力棒",
-		bigBox = "大箱子",
-		trampoline = "彈床",
-		toilet = "馬桶",
-		pig = "豬",
-		sink = "下沉",
-		bathtub = "浴缸",
-		campfire = "營火",
-		chair = "椅子",
-	}
-	translations.ch = translations.cn
-	--[[ End of file translations/parkour/cn.lua ]]--
-	--[[ File translations/parkour/he.lua ]]--
-	translations.he = {
-		name = "he",
-		fullname = "עברית",
-
-		-- Error messages
-		corrupt_map = "<r>מפה משובשת, טוען אחרת.",
-		corrupt_map_vanilla = "<r>[שגיאה] <n>לא ניתן לקבל מידע אודות מפה זו.",
-		corrupt_map_mouse_start = "<r>[שגיאה] <n>דרוש מקום התחלה במפה זו (נקודת התחלה של העכבר).",
-		corrupt_map_needing_chair = "<r>[שגיאה] <n>מפה זו צריכה ספה בנקודה הסופית.",
-		corrupt_map_missing_checkpoints = "<r>[שגיאה] <n>נדרשת לפחות נקודת שמירה אחת במפה זו (נקודה צהובה).",
-		corrupt_data = "<r>למרבה הצער, נתוניך נפגמו ואופסו.",
-		min_players = "<r>על מת שנתוניך ישמרו, חייבים להיות לפחות ארבעה שחקנים שונים בחדר זה. <bl>[%s/%s]",
-		tribe_house = "<r>נתונים לא ישמרו בבתי שבט.",
-		invalid_syntax = "<r>syntax שגוי.",
-		code_error = "<r>שגיאה התגלתה: <bl>%s-%s-%s %s",
-		emergency_mode = "<r>מתחיל כיבוי חירום, אין כניסה לשחקנים חדשים. אנא לך לחדר #parkour אחר.",
-		leaderboard_not_loaded = "<r>הלוח תוצאות עדיין לא נטען, המתן דקה.",
-		max_power_keys = "<v>[#] <r>אתם יכולים שיהיו לכם עד %s כוחות על אותו מקש.",
-
-		-- Help window
-		help = "עזרה",
-		staff = "צוות",
-		rules = "חוקים",
-		contribute = "תרומה",
-		changelog = "חדש",
-		help_help = "<p align = 'center'><font size = '14'>ברוך הבא ל-<T>#parkour!</T></font></p>\n<font size = '12'><p align='center'><J>מטרתך להשיג את כל נקודות השמירה עד שאתה מסיים את המפה.</J></p>\n\n<N>• לחץ <O>ם</O>, כתוב <O>!op</O> או לחץ על <O>גלגל השיניים</O> בכדי לפתוח את <T>ההגדרות</T>.\n• לחץ <O>פ</O> או לחץ על <O>כפתור האגרוף</O> בצד ימין למעלה על מנת לפתוח את <T>תפריט הכוחות</T>.\n• לחץ <O>ך</O> או כתוב <O>!lb</O> בכדי לפתוח את <T>לוח התוצאות</T>.\n• לחץ על <O>צ</O> או כפתור ה-<O>Delete</O> כתחליף ל-<T>/mort</T>, אתה יכול להחליף בין המקשים <J>בהגדרות</J>.\n• על מנת לדעת עוד על <O>הצוות</O> שלנו ועל <O>החוקים של פארקור</O>, לחץ על הכרטיסיות <T>צוות</T> ו<T>חוקים</T> לפי הסדר.\n• לחץ <a href='event:discord'><o>כאן</o></a> בכדי לקבל הזמנה לשרת הדיסקורד ו<a href='event:map_submission'><o>כאן</o></a> בכדי לקבל קישור לנושא הגשת המפות.\n• לחץ על חיצי ה<o>למעלה</o> וה<o>למטה</o> כאשר אתה צריך לגלול.\n\n<p align = 'center'><font size = '13'><T>ניתן כעת לתרום! לפרטים נוספים לחצו על הכרטיסייה <O>תרומה</O> tab!</T></font></p>",
-		help_staff = "<p align = 'center'><font size = '13'><r>הערה: צוות הפארקור אינו צוות המשחק ואין לו שום כוח במשחק עצמו, אלא רק במודול</r>\nצוות הפארקור מוודא כי המודול רץ בצורה חלקה עם עניינים מינימליים והם תמיד זמינים לעזור לשחקנים מתי שצריך.</font></p>\nאתה יכול לכתוב <D>!staff</D> בצ'אט כדי לראות את רשימת הצוות.\n\n<font color = '#E7342A'>אדמינים:</font> הם אחראים לשמור על המודול עי הוספת עדכונים ותיקוני באגים.\n\n<font color = '#D0A9F0'>מנהלי צוות:</font> הם מפקחים על צוותי הניהול והמפות, מוודאים כי הם מבצעים את עבודתם כשורה. בנוסף, הם האחראים על גיוס חברים חדשים לצוות.\n\n<font color = '#FFAAAA'>מנהלים:</font> הם האחראים לאכוף את חוקי המודול והענשת משתמשים אשר לא שומרים עליהם.\n\n<font color = '#25C059'>צוות מפות:</font> הם האחראים על סקירה, הוספה והסרה של מפות במודול הפארקור בכדי להבטיח שיהיה לכם משחק מהנה.",
-		help_rules = "<font size = '13'><B><J>כל החוקים, התנאים וההגבלות של הטראנספורמייס חלים גם על #parkour</J></B></font>\n\nאם אתם מוצאים שחקן אשר עובר על חוקים אלה, שלחו לחישה למנהלי פארקור במשחק. אם אין מנהלים מחוברים, מומלץ לדווח על כך בשרת הדיסקורד.\nכאשר מדווחים, בבקשה כללו את השרת, שם החדר, ושם המשתמש של השחקן.\n• דוגמא: en-#parkour10 Blank#3495 trolling\nהוכחות כגון צילומי מסך, וידאו או גיפס הם יעילים ומוערכים, אך לא חייב.\n\n<font size = '11'>• אין להשתמש ב<font color = '#ef1111'>האקים, גליצ'ים או באגים</font> בחדרי פארקור\n• <font color = '#ef1111'>פארם VPN </font> ייחשב כ<B>ניצול</B> והדבר אסור. <p align = 'center'><font color = '#cc2222' size = '12'><B>\nכל אחד שיתפס עובר על חוקים אלה יורחק באופן מיידי.</B></font></p>\n\n<font size = '12'>טראנספורמייס מרשה לעשות טרולים. עם זאת, <font color='#cc2222'><B>אנו לא נאפשר זאת בפארקור.</B></font></font>\n\n<p align = 'center'><J>טרול זה כאשר שחקן משתמש בכוחותיו או במוצרי זריקה בכוונה תחילה כדי למנוע משחקנים אחרים לסיים את המפה.</j></p>\n• טרול כנקמה הוא <B>אינו סיבה מוצדקת</B> להטריל מישהו ואתם עדיין תענשו.\n• כפיית עזרה על שחקנים שמנסים להשלים לבדם את המפה וסירוב להפסיק כאשר התבקשת לכך ייחשב כטרול.\n• <J>אם שחקן אינו מעוניין בעזרה או מעוניין להשלים לבדו את המפה, אנא נסו ככל יכולתכם לעזור לשחקנים אחרים</J>. עם זאת, אם שחקן אחר צריך עזרה באותה נקודה כמו השחקן השני שרוצה להשלים לבד, אתה יכול לעזור לשניהם.\n\nאם שחקן יתפס מטריל, הוא יענש על בסיס זמן. חשוב לציין כי ביצוע טרול שוב ושוב יוביל לעונשים ארוכים יותר וחמורים יותר.",
-		help_contribute = "<font size='14'>\n<p align='center'>צוות הניהול של פארקור אוהב לפתוח את קוד המקור מכיוון שזה <t>עוזר לקהילה</t>. אתה יכול <o>לראות</o> ו<o>לערוך</o> את קוד המקור ב-<o><u><a href='event:github'>GitHub</a></u></o>.\n\nשמירה על המודול היא <t>התנדבותית לחלוטין</t>. לכן, כל עזרה ב<t>קודים</t>, <t>דיווח על באגים</t>, <t>הצעות</t> ו<t>יצירת מפות</t> תמיד <u>מתקבלת בברכה ומוערכת</u>.\nאתה יכול <vp>לדווח אודות באגים</vp> ו<vp>להציע הצעות</vp> ב<o><u><a href='event:discord'>דיסקורד</a></u></o> ו/או ב-<o><u><a href='event:github'>GitHub</a></u></o>.\nאתה יכול <vp>להגיש את מפותיך</vp> ב<o><u><a href='event:map_submission'>נושא הפורום</a></u></o> שלנו.\n\nאחזקת פארקור איננה יקרה, אך גם איננה חינמית. אנו נשמח אם תוכלו לעזור לנו עי <t>תרומה בכל סכום</t> <o><u><a href='event:donate'>כאן</a></u></o>.\n<u>כל התרומות הולכות היישר לשיפור המודול.</u></p>",
-		help_changelog = "<font size='13'><p align='center'><o>Version 2.10.0 - 17/04/2021</o></p>\n\n<font size='11'>• <font size='13'><b><j>THREE</J></b> brand new Transformice titles that can only be unlocked by playing <font color='#1A7EC9'><b>#parkour</b></font>!</font>\n• Two new statuses added to the profile.\n• Minor text adjustments.",
-
-		-- Congratulation messages
-		reached_level = "<d>ברכות! עלית לרמה <vp>%s</vp>. (<t>%ss</t>)",
-		finished = "<d><o>%s</o> סיים את הפארקור תוך <vp>%s</vp> שניות, <fc>ברכות!",
-		unlocked_power = "<ce><d>%s</d> השיג את הכח <vp>%s</vp>.",
-
-		-- Information messages
-		mod_apps = "<j>הגשות מועמדות להיות מנהל/ת פארקור פתוחות כעת! השתמש בקישור זה: <rose>%s",
-		staff_power = "<r>לצוות פארקור <b>אין</b> שום כוחות מחוץ לחדרי פארקור.",
-		donate = "<vp>הקלד <b>!donate</b> אם תרצה לתרום עבור מודול זה!",
-		paused_events = "<cep><b>[אזהרה!]</b> <n>המשחק הגיע למגבלה קריטית ונעצר כעת.",
-		resumed_events = "<n2>המשחק נמשך.",
-		welcome = "<n>ברוכים הבאים ל<t>#parkour</t>!",
-		module_update = "<r><b>[אזהרה!]</b> <n>המשחק יעדוכן בעוד <d>%02d:%02d</d>.",
-		leaderboard_loaded = "<j>לוח התוצאות נטען. לחץ L כדי לפתוח אותו.",
-		kill_minutes = "<R>כוחותיך הושבתו ל-%s דקות.",
-		permbanned = "<r>הורחקת לצמיתות מ-#parkour.",
-		tempbanned = "<r>הורחקת מ-#parkour למשך %s דקות.",
-		forum_topic = "<rose>למידע נוסף אודות פארקור כנסו לקישור: %s",
-		report = "<j>רוצים לדווח על שחקן? <t><b>/c Parkour#8558 .report Username#0000</b></t>",
-
-		-- Easter Eggs
-		easter_egg_0  = "<ch>הספירה מתחילה...",
-		easter_egg_1  = "<ch>פחות מ24 שעות נותרו!",
-		easter_egg_2  = "<ch>וואו, הגעת מוקדם! גם אתה מתרגש?",
-		easter_egg_3  = "<ch>הפתעה מחכה...",
-		easter_egg_4  = "<ch>אתה יודע מה הולך לקרות...?",
-		easter_egg_5  = "<ch>השעון ממשיך לתקתק...",
-		easter_egg_6  = "<ch>ההפתעה קרבה!",
-		easter_egg_7  = "<ch>המסיבה עוד רגע מתחילה...",
-		easter_egg_8  = "<ch>תסתכל בשעות, כבר הגיע הזמן?",
-		easter_egg_9  = "<ch>תיזהר, הזמן עובר מהר...",
-		easter_egg_10 = "<ch>פשוט שב ותירגע, מחר יגיע במהרה!",
-		easter_egg_11 = "<ch>לך לישון מוקדם, זה יגרום לזמן לעבור מהר יותר!",
-		easter_egg_12 = "<ch>סבלנות היא מעלה",
-		easter_egg_13 = "<ch>https://youtu.be/9jK-NcRmVcw",
-		double_maps = "<bv>מפות כפולות וכל הכוחות זמינים בשביל שבוע היום הולדת של פארקור!",
-		double_maps_start = "<rose>זה שבוע היום הולדת של פארקור! מפות כפולות וכל הכוחות הופעלו.תודה שאתם משחקים איתנו!",
-		double_maps_end = "<rose>שבוע היום הולדת של פארקור נגמר. תודה ששיחקתם!",
-
-		-- Records
-		records_enabled = "<v>[#] <d>מצב שיאים הופעל בחדר זה. סטטיסטיקה לא תיחשב וכוחות לא יפעלו. תוכלו למצוא מידע נוסף על שיאים ב <b>%s</b>",
-		records_admin = "<v>[#] <d>הנך מנהל של חדר השיאים הזה. אתה יכול להשתמש בפקודות <b>!map</b>, <b>!setcp</b>, <b>!pw</b> ו-<b>!time</b>.",
-		records_completed = "<v>[#] <d>השלמתם את המפה! אם ברצונכם להשלימה שוב, כתבו <b>!redo</b>.",
-		records_submit = "<v>[#] <d>וואו! נראה שיש לכם את הזמן הכי מהיר בחדר. אם ברצונכם להגיש את השיא, כתבו <b>!submit</b>.",
-		records_invalid_map = "<v>[#] <r>נראה כי מפה זו אינה חלק ממפות פארקור... אינכם יכולים להגיש שיא בשבילה!",
-		records_not_fastest = "<v>[#] <r>נראה כי אינך השחקן הכי מהיר בחדר...",
-		records_already_submitted = "<v>[#] <r>כבר הגשת את השיא שלך בשביל מפה זו!",
-		records_submitted = "<v>[#] <d>השיא שלך למפה <b>%s</b> הוגש.",
-
-		-- Miscellaneous
-		afk_popup = "\n<p align='center'><font size='30'><bv><b>אתה במצב AFK</b></bv>\nזוז כדי לחזור</font>\n\n<font size='30'><u><t>תזכורות:</t></u></font>\n\n<font size='15'><r>שחקנים עם קו אדום מעליהם אינם מעוניינים בעזרה!\nהטרלת/חסימת שחקנים אחרים בפארקור אסורה!<d>\nהצטרפו ל<cep><a href='event:discord'>שרת הדיסקורד</a></cep> שלנו!\nרוצה לתרום קוד? ראה את <cep><a href='event:github'>מאגר ה-GitHub</a></cep> שלנו.\nיש לך מפה טובה להגיש?  שלח את זה ב<cep><a href='event:map_submission'>נושא הגשת המפות</a></cep> שלנו\nבידקו את <cep><a href='event:forum'>הנושא הרשמי</a></cep> שלנו למידע נוסף!\nתמוך בנו על ידי <cep><a href='event:donate'>תרומה!</a></cep>",
-		options = "<p align='center'><font size='20'>אפשרויות פארקור</font></p>\n\nהשתמש במקלדת <b>QWERTY</b> (כבה אם <b>AZERTY</b> בשימוש)\n\nהשתמש באות <b>צ</b> במקום <b>/mort</b> (משבית את <b>DEL</b>)\n\nהראה את זמן טעינת הכוחות\n\nהראה כפתור כוחות\n\nהראה כפתור עזרה\n\nהראה הכרזות השלמת מפות\n\nהצג סימן 'ללא עזרה'",
-		cooldown = "<v>[#] <r>המתן מספר שניות לפני שאתה עושה זאת.",
-		power_options = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><b>QWERTY</b> מקלדת" ..
-						 "\n\n<b>הסתר</b> ספירת מפות" ..
-						 "\n\nהשתמש ב<b>מקשים מקוריים</b>"),
-		unlock_power = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>השלם <v>%s</v> מפות" ..
-						"<font size='5'>\n\n</font>בכדי להשיג" ..
-						"<font size='5'>\n\n</font><v>%s</v>"),
-		upgrade_power = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>השלם <v>%s</v> מפות" ..
-						"<font size='5'>\n\n</font>כדי לשדרג ל" ..
-						"<font size='5'>\n\n</font><v>%s</v>"),
-		unlock_power_rank = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>דרגה <v>%s</v>" ..
-						"<font size='5'>\n\n</font>בכדי להשיג" ..
-						"<font size='5'>\n\n</font><v>%s</v>"),
-		upgrade_power_rank = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>דרגה <v>%s</v>" ..
-						"<font size='5'>\n\n</font>כדי לשדרג ל" ..
-						"<font size='5'>\n\n</font><v>%s</v>"),
-		maps_info = ("<p align='center'><font size='13' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
-					 "<font size='5'>\n\n</font>מפות שהושלמו"),
-		overall_info = ("<p align='center'><font size='13' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
-						"<font size='5'>\n\n</font>לוח תוצאות כללי"),
-		weekly_info = ("<p align='center'><font size='13' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
-					   "<font size='5'>\n\n</font>לוח תוצאות שבועי"),
-		badges = "<font size='14' face='Lucida Console,Liberation Mono,Courier New,Verdana'>תגים (%s): <a href='event:_help:badge'><j>[?]</j></a>",
-		private_maps = "<bl>מספר המפות של שחקן זה הינו פרטי. <a href='event:_help:private_maps'><j>[?]</j></a></bl>\n",
-		profile = ("<font size='12' face='Lucida Console,Liberation Mono,Courier New,Verdana'>%s%s %s\n\n" ..
-					"דרגה בלוח התוצאות הכללי: <b><v>%s</v></b>\n\n" ..
-					"דרגה בלוח התוצאות השבועי: <b><v>%s</v></b>\n\n%s"),
-		map_count = "מספר מפות: <b><v>%s</v> / <a href='event:_help:yellow_maps'><j>%s</j></a> / <a href='event:_help:red_maps'><r>%s</r></a></b>",
-		help_badge = "תגים הינם הישגים ששחקן יכול לקבל. לחץ עליהם על מנת לקבל פירוט.",
-		help_private_maps = "משתמש זה אינו מעוניין לשתף את מספר המפות שלו בפומבי! אתה יכול להסתיר את זה גם בפרופיל שלך.",
-		help_yellow_maps = "מפות בצהוב הן מפות שהושלמו בשבוע זה.",
-		help_red_maps = "מפות באדום הן מפות שהושלמו בשעה האחרונה.",
-		help_badge_1 = "משתמש זה היה חלק מצוות הפארקור בעבר.",
-		help_badge_2 = "משתמש זה נמצא או היה בעמוד הראשון של לוח התוצאות הכללי.",
-		help_badge_3 = "משתמש זה נמצא או היה בעמוד השני של לוח התוצאות הכללי.",
-		help_badge_4 = "משתמש זה נמצא או היה בעמוד השלישי של לוח התוצאות הכללי.",
-		help_badge_5 = "משתמש זה נמצא או היה בעמוד הרביעי של לוח התוצאות הכללי.",
-		help_badge_6 = "משתמש זה נמצא או היה בעמוד החמישי של לוח התוצאות הכללי.",
-		help_badge_7 = "שחקן זה היה בפודיום בסוף של לוח התוצאות השבועי בסוף שבוע",
-		help_badge_8 = "השחקן הזה השיג שיא של 30 מפות תוך שעה.",
-		help_badge_9 = "השחקן הזה השיג שיא של 35 מפות תוך שעה.",
-		help_badge_10 = "השחקן הזה השיג שיא של 40 מפות תוך שעה.",
-		help_badge_11 = "השחקן הזה השיג שיא של 45 מפות תוך שעה.",
-		help_badge_12 = "השחקן הזה השיג שיא של 50 מפות תוך שעה.",
-		help_badge_13 = "השחקן הזה השיג שיא של 55 מפות תוך שעה.",
-		help_badge_14 = "שחקן זה אימת את משתמש הדיסקורד שלו בשרת הדיסקורד הרשמי של פארקור (כתבו <b>!discord</b>).",
-		help_badge_15 = "שחקן זה עשה את הזמן המהיר ביותר במפה אחת.",
-		help_badge_16 = "שחקן זה עשה את הזמן המהיר ביותר ב-5 מפות.",
-		help_badge_17 = "שחקן זה עשה את הזמן המהיר ביותר ב-10 מפות.",
-		help_badge_18 = "שחקן זה עשה את הזמן המהיר ביותר ב-15 מפות.",
-		help_badge_19 = "שחקן זה עשה את הזמן המהיר ביותר ב-20 מפות.",
-		help_badge_20 = "שחקן זה עשה את הזמן המהיר ביותר ב-25 מפות.",
-		help_badge_21 = "שחקן זה עשה את הזמן המהיר ביותר ב-30 מפות.",
-		help_badge_22 = "שחקן זה עשה את הזמן המהיר ביותר ב-35 מפות.",
-		help_badge_23 = "שחקן זה עשה את הזמן המהיר ביותר ב-40 מפות.",
-		make_public = "הפוך לציבורי",
-		make_private = "הפוך לפרטי",
-		moderators = "מנהלים",
-		mappers = "צוות מפות",
-		managers = "מנהלי צוות",
-		administrators = "אדמינים",
-		close = "סגור",
-		cant_load_bot_profile = "<v>[#] <r>אינך יכול לראות את הפרופיל של הבוט הזה כיוון שפארקור משתמש בו באופן פנימי כדי לעבוד בצורה ראויה.",
-		cant_load_profile = "<v>[#] <r>השחקן <b>%s</b> ככל הנראה מנותק או איננו קיים.",
-		like_map = "האם אתה אוהב את המפה הזו?",
-		yes = "כן",
-		no = "לא",
-		idk = "לא יודע",
-		unknown = "לא ידוע",
-		powers = "כוחות",
-		press = "<vp>לחץ %s",
-		click = "<vp>לחיצה שמאלית",
-		ranking_pos = "דרגה #%s",
-		completed_maps = "<p align='center'><BV><B>מפות שהושלמו: %s</B></p></BV>",
-		leaderboard = "לוח תוצאות",
-		position = "<V><p align=\"center\">דרגה",
-		username = "<V><p align=\"center\">שם משתמש",
-		community = "<V><p align=\"center\">קהילה",
-		completed = "<V><p align=\"center\">מפות שהושלמו",
-		overall_lb = "כללי",
-		weekly_lb = "שבועי",
-		new_lang = "<v>[#] <d>השפה הוגדרה ל-עברית",
-
-		-- Power names
-		balloon = "בלון",
-		masterBalloon = "מאסטר בלון",
-		bubble = "בועה",
-		fly = "תעופה",
-		snowball = "כדור שלג",
-		speed = "מהירות",
-		teleport = "שיגור",
-		smallbox = "קופסא קטנה",
-		cloud = "ענן",
-		rip = "קבר",
-		choco = "קרש שוקולד",
-		bigBox = "קופסא גדולה",
-		trampoline = "טרמפולינה",
-		toilet = "אסלה",
-		pig = "חזיר",
-		sink = "כיור",
-		bathtub = "אמבטיה",
-		campfire = "מדורה",
-		chair = "כסא",
-	}
-	--[[ End of file translations/parkour/he.lua ]]--
-	--[[ File translations/parkour/br.lua ]]--
-	translations.br = {
-		name = "br",
-		fullname = "Português",
-
-		-- Error messages
-		corrupt_map = "<r>Mapa corrompido. Carregando outro.",
-		corrupt_map_vanilla = "<r>[ERROR] <n>Não foi possível obter informações deste mapa.",
-		corrupt_map_mouse_start = "<r>[ERROR] <n>O mapa requer um ponto de partida (spawn).",
-		corrupt_map_needing_chair = "<r>[ERROR] <n>O mapa requer a poltrona final.",
-		corrupt_map_missing_checkpoints = "<r>[ERROR] <n>O mapa requer ao menos um checkpoint (prego amarelo).",
-		corrupt_data = "<r>Infelizmente seus dados corromperam e foram reiniciados.",
-		min_players = "<r>Para que dados sejam salvos, ao menos 4 jogadores únicos devem estar na sala. <bl>[%s/%s]",
-		tribe_house = "<r>Para que dados sejam salvos, você precisa jogar fora de um cafofo de tribo.",
-		invalid_syntax = "<r>Sintaxe inválida.",
-		code_error = "<r>Um erro aconteceu: <bl>%s-%s-%s %s",
-		emergency_mode = "<r>Começando desativação de emergência, novos jogadores não serão mais permitidos. Por favor, vá para outra sala #parkour.",
-		leaderboard_not_loaded = "<r>O ranking ainda não foi carregado. Aguarde um minuto.",
-		max_power_keys = "<v>[#] <r>Você pode ter no máximo %s poderes na mesma tecla.",
-
-		-- Help window
-		help = "Ajuda",
-		staff = "Staff",
-		rules = "Regras",
-		contribute = "Contribuir",
-		changelog = "Novidades",
-		help_help = "<p align = 'center'><font size = '14'>Bem-vindo ao <T>#parkour!</T></font></p>\n<font size = '12'><p align='center'><J>Seu objetivo é chegar em todos os checkpoints até que você complete o mapa.</J></p>\n\n<N>• Aperte <O>O</O>, digite <O>!op</O> ou clique no <O>botão de configuração</O> para abrir o <T>menu de opções</T>.\n• Aperte <O>P</O> ou clique no <O>ícone de mão</O> no parte superior direita para abrir o <T>menu de poderes</T>.\n• Aperte <O>L</O> ou digite <O>!lb</O> parar abrir o <T>ranking</T>.\n• Aperte <O>M</O> ou a tecla <O>Delete</O> para <T>/mort</T>, você pode alterar as teclas no moenu de <J>Opções</J>.\n• Para saber mais sobre nossa <O>staff</O> e as <O>regras do parkour</O>, clique nas abas <T>Staff</T> e <T>Regras</T>, respectivamente.\n• Clique <a href='event:discord'><o>aqui</o></a> para obter um link de convide para o nosso servidor no Discord e <a href='event:map_submission'><o>aqui</o></a> para obter o link do tópico de avaliação de mapas.\n• Use as setas <o>para cima</o> ou <o>para baixo</o> quando você precisar rolar a página.\n\n<p align = 'center'><font size = '13'><T>Contribuições agora estão disponíveis! Para mais detalhes, clique na aba <O>Contribuir</O>!</T></font></p>",
-		help_staff = "<p align = 'center'><font size = '13'><r>AVISO: A staff do Parkour não faz parte da staff do Transformice e não tem nenhum poder no jogo em si, apenas no módulo.</r>\nStaff do Parkour assegura que o módulo rode com problemas mínimos, e estão sempre disponíveis para dar assistência aos jogadores quando necessário.</font></p>\nVocê pode digitar <D>!staff</D> no chat para ver a lista de staff.\n\n<font color = '#E7342A'>Administradores:</font> São responsáveis por manter o módulo propriamente dito, atualizando-o e corrigindo bugs.\n\n<font color = '#D0A9F0'>Gerenciadores das Equipes:</font> Observam as equipes de Moderação e de Mapas, assegurando que todos estão fazendo um bom trabalho. Também são responsáveis por recrutar novos membros para a staff.\n\n<font color = '#FFAAAA'>Moderadores:</font> São responsáveis por aplicar as regras no módulo e punir aqueles que não as seguem.\n\n<font color = '#25C059'>Mappers:</font> São responsáveis por avaliar, adicionar e remover mapas do módulo para assegurar que você tenha uma jogatina divertida.",
-		help_rules = "<font size = '13'><B><J>Todas as regras nos Termos e Condições de Uso do Transformice também se aplicam no #parkour</J></B></font>\n\nSe você encontrar algum jogador quebrando-as, cochiche com um moderador do #parkour no jogo. Se os moderadores não estiverem online, recomendamos que reporte em nosso servidor no Discord.\nAo reportar, por favor inclua a comunidade, o nome da sala e o nome do jogador.\n• Ex: en-#parkour10 Blank#3495 trolling\nEvidências, como prints, vídeos e gifs são úteis e apreciados, mas não necessários.\n\n<font size = '11'>• Uso de <font color = '#ef1111'>hacks, glitches ou bugs</font> são proibidos em salas #parkour\n• <font color = '#ef1111'>Farm VPN</font> será considerado um <B>abuso</B> e não é permitido. <p align = 'center'><font color = '#cc2222' size = '12'><B>\nQualquer um pego quebrando as regras será banido imediatamente.</B></font></p>\n\n<font size = '12'>Transformice permite trollar. No entanto, <font color='#cc2222'><B>não permitiremos isso no parkour.</B></font></font>\n\n<p align = 'center'><J>Trollar é quando um jogador intencionalmente usa seus poderes ou consumíveis para fazer com que outros jogadores não consigam terminar o mapa.</j></p>\n• Trollar por vingança <B>não é um motivo válido</B> e você ainda será punido.\n• Insistir em ajudar jogadores que estão tentando terminar o mapa sozinhos e se recusando a parar quando pedido também será considerado trollar.\n• <J>Se um jogador não quer ajuda e prefere completar o mapa sozinho, dê seu melhor para ajudar os outros jogadores</J>. No entanto, se outro jogador que precisa de ajuda estiver no mesmo checkpoint daquele que quer completar sozinho, você pode ajudar ambos sem receber punição.\n\nSe um jogador é pego trollando, será punido em uma questão de tempo. Note que trollar repetidamente irá fazer com que você receba punições gradativamente mais longas e/ou severas.",
-		help_contribute = "<font size='14'>\n<p align='center'>A equipe do parkour adora ter um código aberto, pois isso <t>ajuda a comunidade</t>. Você pode <o>ver</o> ou <o>contribuir</o> com o código no <o><u><a href='event:github'>GitHub</a></u></o>.\n\nManter o módulo é parte de um trabalho <t>voluntário</t>, então qualquer contribuição é <u>bem vinda</u>, seja com a <t>programação</t>, <t>reporte de erros</t>, <t>sugestões</t> e <t>criação de mapas</t>.\nVocê pode <vp>reportar erros</vp> ou <vp>dar sugestões</vp> no nosso <o><u><a href='event:discord'>Discord</a></u></o> e/ou no <o><u><a href='event:github'>GitHub</a></u></o>.\nVocê pode <vp>enviar seus mapas</vp> no nosso <o><u><a href='event:map_submission'>Tópico no Fórum</a></u></o>.\n\nManter o jogo não é caro, mas também não é grátis. Nós adoraríamos se você pudesse incentivar o desenvolvimento do jogo <t>doando qualquer valor</t> <o><u><a href='event:donate'>aqui</a></u></o>.\n<u>Todos os fundos arrecadados serão direcionados para o desenvolvimento do módulo.</u></p>",
-		help_changelog = "<font size='13'><p align='center'><o>Versão 2.10.0 - 17/04/2021</o></p>\n\n<font size='11'>• <font size='13'><b><j>TRÊS</J></b> novos títulos no Transformice que só podem ser desbloqueados jogando <font color='#1A7EC9'><b>#parkour</b></font>!</font>\n• Duas novas estatísticas adicionadas no perfil.\n• Ajustes menores em textos.",
-
-		-- Congratulation messages
-		reached_level = "<d>Parabéns! Você atingiu o nível <vp>%s</vp>. (<t>%ss</t>)",
-		finished = "<d><o>%s</o> terminou o parkour em <vp>%s</vp> segundos, <fc>parabéns!",
-		unlocked_power = "<ce><d>%s</d> desbloqueou o poder <vp>%s</vp>.",
-
-		-- Information messages
-		mod_apps = "<j>As inscrições para moderador do parkour estão abertas! Use esse link: <rose>%s",
-		staff_power = "<r>A Staff do Parkour <b>não</b> tem nenhum poder fora das salas #parkour.",
-		donate = "<vp>Digite <b>!donate</b> se você gostaria de doar para este módulo!",
-		paused_events = "<cep><b>[Atenção!]</b> <n>O módulo está atingindo um estado crítico e está sendo pausado.",
-		resumed_events = "<n2>O módulo está se normalizando.",
-		welcome = "<n>Bem-vindo(a) ao <t>#parkour</t>!",
-		module_update = "<r><b>[Atenção!]</b> <n>O módulo irá atualizar em <d>%02d:%02d</d>.",
-		leaderboard_loaded = "<j>O ranking foi carregado. Aperte L para abri-lo.",
-		kill_minutes = "<R>Seus poderes foram desativados por %s minutos.",
-		permbanned = "<r>Você foi banido permanentemente do #parkour.",
-		tempbanned = "<r>Você foi banido do #parkour por %s minutos.",
-		forum_topic = "<rose>Para mais informações sobre o módulo, acesse o link: %s",
-		report = "<j>Quer reportar um jogador? <t><b>/c Parkour#8558 .report NomeJogador#0000</b></t>",
-
-		-- Easter Eggs
-		easter_egg_0  = "<ch>E a contagem regressiva começa...",
-		easter_egg_1  = "<ch>Menos de 24 horas restantes!",
-		easter_egg_2  = "<ch>Eita, você está muito adiantado! Está muito ansioso?",
-		easter_egg_3  = "<ch>Uma surpresa está no forno...",
-		easter_egg_4  = "<ch>Você sabe o que está prestes a acontecer...?",
-		easter_egg_5  = "<ch>O tempo está passando...",
-		easter_egg_6  = "<ch>A surpresa está próxima!",
-		easter_egg_7  = "<ch>A festa está prestes a começar...",
-		easter_egg_8  = "<ch>Que horas são? Já deu a hora?",
-		easter_egg_9  = "<ch>Atente-se, o tempo está passando...",
-		easter_egg_10 = "<ch>Apenas sente e relaxe, será amanhã sem horário definido!",
-		easter_egg_11 = "<ch>Vamos para a cama mais cedo, o tempo vai passar mais rápido!",
-		easter_egg_12 = "<ch>Paciência é uma virtude",
-		easter_egg_13 = "<ch>https://youtu.be/9jK-NcRmVcw",
-		double_maps = "<bv>Você ganhará duas vezes mais vitórias no Sábado (GMT+2) e todos os poderes estarão disponíveis na semana de aniversário do Parkour!",
-		double_maps_start = "<rose>É A SEMANA DE ANIVERSÁRIO DO PARKOUR! Você ganhará duas vezes mais vitórias e todos os poderes foram ativados. Muito obrigado por jogar com a gente!",
-		double_maps_end = "<rose>A semana de aniversário do Parkour terminou. Muito obrigado por jogar com a gente!",
-
-		-- Records
-		records_enabled = "<v>[#] <d>Modo Records está ativado nesta sala. Dados não serão contados e poderes não estão ativados!\nVocê poderá encontrar mais informações sobre records em <b>%s</b>",
-		records_admin = "<v>[#] <d>Você é um administrador desta sala de records. Você pode usar os comandos <b>!map</b>, <b>!setcp</b>, <b>!pw</b> e <b>!time</b>.",
-		records_completed = "<v>[#] <d>Você completou o mapa! Se você quiser jogar nele novamente, digite <b>!redo</b>.",
-		records_submit = "<v>[#] <d>Wow! Parece que você teve o melhor tempo nesta sala. Se você quiser enviar o record, digite <b>!submit</b>.",
-		records_invalid_map = "<v>[#] <r>Parece que este mapa não está na rotação de mapas do parkour... Você não pode enviar um recorde para ele",
-		records_not_fastest = "<v>[#] <r>Parece que você não é o jogador mais rápido na sala...",
-		records_already_submitted = "<v>[#] <r>Você já enviou seu recorde para este mapa!",
-		records_submitted = "<v>[#] <d>Seu recorde para o mapa <b>%s</b> foi enviado.",
-
-		-- Miscellaneous
-		afk_popup = "\n<p align='center'><font size='30'><bv><b>VOCê ESTÁ NO MODO AFK</b></bv>\nMOVA-SE PARA RENASCER</font>\n\n<font size='30'><u><t>Lembretes:</t></u></font>\n\n<font size='15'><r>Jogadores com uma linha vermelha em cima deles não querem ajuda!\nTrollar/bloquear outros jogadores no parkour NÃO é permitido!<d>\nEntre em nosso <cep><a href='event:discord'>servidor no Discord</a></cep>!\nQuer contribuir com código? Veja nosso <cep><a href='event:github'>repositório no Github</a></cep>\nVocê tem um mapa bom pra enviar? Mande-o em nosso <cep><a href='event:map_submission'>tópico de submissão de mapas</a></cep>\nCheque nosso <cep><a href='event:forum'>tópico oficial no fórum</a></cep> para mais informações!\nNos apoie com <cep><a href='event:donate'>doações!</a></cep>",
-		options = "<p align='center'><font size='20'>Opções do Parkour</font></p>\n\nUsar o teclado <b>QWERTY</b> (desativar caso seja <b>AZERTY</b>)\n\nUsar a tecla <b>M</b> como <b>/mort</b> (desativar caso seja <b>DEL</b>)\n\nMostrar o delay do seu poder\n\nMostrar o botão de poderes\n\nMostrar o botão de ajuda\n\nMostrar mensagens de mapa completado\n\nMostrar símbolo de não ajudar",
-		cooldown = "<v>[#] <r>Aguarde alguns segundos antes de fazer isso novamente.",
-		power_options = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'>Teclado <b>QWERTY</b>" ..
-						 "\n\n<b>Esconder</b> contagem de mapas" ..
-						 "\n\nUsar <b>tecla padrão</b>"),
-		unlock_power = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Complete <v>%s</v> mapas" ..
-						"<font size='5'>\n\n</font>para desbloquear" ..
-						"<font size='5'>\n\n</font><v>%s</v>"),
-		upgrade_power = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Complete <v>%s</v> mapas" ..
-						"<font size='5'>\n\n</font>para evoluir para" ..
-						"<font size='5'>\n\n</font><v>%s</v>"),
-		unlock_power_rank = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Seja top <v>%s</v>" ..
-						"<font size='5'>\n\n</font>para desbloquear" ..
-						"<font size='5'>\n\n</font><v>%s</v>"),
-		upgrade_power_rank = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Seja top <v>%s</v>" ..
-						"<font size='5'>\n\n</font>para evoluir para" ..
-						"<font size='5'>\n\n</font><v>%s</v>"),
-		maps_info = ("<p align='center'><font size='13' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
-					 "<font size='5'>\n\n</font>Mapas completados"),
-		overall_info = ("<p align='center'><font size='13' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
-						"<font size='5'>\n\n</font>Ranking Geral"),
-		weekly_info = ("<p align='center'><font size='13' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
-					   "<font size='5'>\n\n</font>Ranking Semanal"),
-		badges = "<font size='14' face='Lucida Console,Liberation Mono,Courier New,Verdana'>Medalhas (%s): <a href='event:_help:badge'><j>[?]</j></a>",
-		private_maps = "<bl>A contagem de mapas deste jogador é privado. <a href='event:_help:private_maps'><j>[?]</j></a></bl>\n",
-		profile = ("<font size='12' face='Lucida Console,Liberation Mono,Courier New,Verdana'>%s%s %s\n\n" ..
-					"Posição no Ranking geral: <b><v>%s</v></b>\n\n" ..
-					"Posição no Ranking semanal: <b><v>%s</v></b>\n\n%s"),
-		map_count = "Contagem de mapas: <b><v>%s</v> / <a href='event:_help:yellow_maps'><j>%s</j></a> / <a href='event:_help:red_maps'><r>%s</r></a></b>",
-		title_count = ("<b><j>«!»</j></b> Mapas completados: <b><a href='event:_help:map_count_title'><v>%s</v></a></b>\n\n" ..
-			"<b><j>«!»</j></b> Checkpoints coletados: <b><a href='event:_help:checkpoint_count_title'><v>%s</v></a></b>"),
-		help_badge = "Medalhas são objetivos que um jogador pode conseguir. Clique nelas para ler suas descrições.",
-		help_private_maps = "Este jogador não gosta de divulgar sua contagem de mapas publicamente! Você também pode escondê-la em seu perfil.",
-		help_yellow_maps = "Mapas em amarelo são os mapas completados nesta semana.",
-		help_red_maps = "Mapas em vermelho são os mapas completados na última hora.",
-		help_map_count_title = "Você pode conseguir títulos no <b>Transformice</b> ao completar mapas parkour!",
-		help_checkpoint_count_title = "Você pode conseguir títulos no <b>Transformice</b> ao coletar todos os checkpoints em mapas parkour!",
-		help_badge_1 = "Este jogador já foi um membro da staff do #parkour no passado.",
-		help_badge_2 = "Este jogador está ou já esteve na página 1 do ranking global.",
-		help_badge_3 = "Este jogador está ou já esteve na página 2 do ranking global.",
-		help_badge_4 = "Este jogador está ou já esteve na página 3 do ranking global.",
-		help_badge_5 = "Este jogador está ou já esteve na página 4 do ranking global.",
-		help_badge_6 = "Este jogador está ou já esteve na página 5 do ranking global.",
-		help_badge_7 = "Este jogador esteve no pódio no fim de um ranking semanal.",
-		help_badge_8 = "Este jogador bateu um recorde de 30 mapas por hora.",
-		help_badge_9 = "Este jogador bateu um recorde de 35 mapas por hora.",
-		help_badge_10 = "Este jogador bateu um recorde de 40 mapas por hora.",
-		help_badge_11 = "Este jogador bateu um recorde de 45 mapas por hora.",
-		help_badge_12 = "Este jogador bateu um recorde de 50 mapas por hora.",
-		help_badge_13 = "Este jogador bateu um recorde de 55 mapas por hora.",
-		help_badge_14 = "Este jogador verificou sua conta no servidor oficial do Parkour no Discord (digite <b>!discord</b>).",
-		help_badge_15 = "Este jogador teve o tempo mais rápido em 1 mapa.",
-		help_badge_16 = "Este jogador teve o tempo mais rápido em 5 mapas.",
-		help_badge_17 = "Este jogador teve o tempo mais rápido em 10 mapas.",
-		help_badge_18 = "Este jogador teve o tempo mais rápido em 15 mapas.",
-		help_badge_19 = "Este jogador teve o tempo mais rápido em 20 mapas.",
-		help_badge_20 = "Este jogador teve o tempo mais rápido em 25 mapas.",
-		help_badge_21 = "Este jogador teve o tempo mais rápido em 30 mapas.",
-		help_badge_22 = "Este jogador teve o tempo mais rápido em 35 mapas.",
-		help_badge_23 = "Este jogador teve o tempo mais rápido em 40 mapas.",
-		make_public = "tornar público",
-		make_private = "tornar privado",
-		moderators = "Moderadores",
-		mappers = "Mappers",
-		managers = "Gerentes",
-		administrators = "Administradores",
-		close = "Fechar",
-		cant_load_bot_profile = "<v>[#] <r>Você não pode ver o perfil deste bot já que o #parkour utiliza-o internamente para funcionar devidamente.",
-		cant_load_profile = "<v>[#] <r>O jogador <b>%s</b> parece estar offline ou não existe.",
-		like_map = "Você gosta deste mapa?",
-		yes = "Sim",
-		no = "Não",
-		idk = "Não sei",
-		unknown = "Desconhecido",
-		powers = "Poderes",
-		press = "<vp>Aperte %s",
-		click = "<vp>Use click",
-		ranking_pos = "Rank #%s",
-		completed_maps = "<p align='center'><BV><B>Mapas completados: %s</B></p></BV>",
-		leaderboard = "Ranking",
-		position = "<V><p align=\"center\">Posição",
-		username = "<V><p align=\"center\">Nome",
-		community = "<V><p align=\"center\">Comunidade",
-		completed = "<V><p align=\"center\">Mapas completados",
-		overall_lb = "Geral",
-		weekly_lb = "Semanal",
-		new_lang = "<v>[#] <d>Idioma definido para Português",
-
-		-- Power names
-		balloon = "Balão",
-		masterBalloon = "Balão Mestre",
-		bubble = "Bolha",
-		fly = "Voar",
-		snowball = "Bola de Neve",
-		speed = "Velocidade",
-		teleport = "Teleporte",
-		smallbox = "Caixa Pequena",
-		cloud = "Nuvem",
-		rip = "Lápide",
-		choco = "Choco-tábua",
-		bigBox = "Caixa grande",
-		trampoline = "Trampolim",
-		toilet = "Vaso Sanitário",
-		pig = "Leitão",
-		sink = "Pia",
-		bathtub = "Banheira",
-		campfire = "Fogueira",
-		chair = "Cadeira",
-	}
-	translations.pt = translations.br
-	--[[ End of file translations/parkour/br.lua ]]--
-	--[[ File translations/parkour/fr.lua ]]--
-	translations.fr = {
-		name = "fr",
-		fullname = "Français",
-
-		-- Error messages
-		corrupt_map = "<r>Carte non opérationnelle. Chargement d'une autre.",
-		corrupt_map_vanilla = "<r>[ERROR] <n>Impossible de récolter les informations de cette carte.",
-		corrupt_map_mouse_start = "<r>[ERROR] <n>Cette carte a besoin d'un point d'apparition (pour les souris).",
-		corrupt_map_needing_chair = "<r>[ERROR] <n>La carte a besoin d'une chaise d'arrivée (point final).",
-		corrupt_map_missing_checkpoints = "<r>[ERROR] <n>La carte a besoin d'au moins un point de sauvegarde (étoiles jaunes).",
-		corrupt_data = "<r>Malheureusement, tes données ont été corrompues et ont été effacées.",
-		min_players = "<r>Pour sauvegarder les données, il doit y avoir au moins 4 souris dans le salon. <bl>[%s/%s]",
-		tribe_house = "<r>Les données ne sont pas sauvegardées dans les maisons de tribu.",
-		invalid_syntax = "<r>Syntaxe invalide.",
-		code_error = "<r>Une erreur est survenue: <bl>%s-%s-%s %s",
-		emergency_mode = "<r>Mise en place du blocage d'urgence, aucun nouveau joueur ne peut rejoindre. Merci d'aller dans un autre salon #parkour.",
-		leaderboard_not_loaded = "<r>Le tableau des scores n'a pas été encore chargé. Attendez une minute.",
-		max_power_keys = "<v>[#] <r>Vous pouvez avoir maximum %s pouvoirs sur la même touche.",
-
-		-- Help window
-		help = "Aide",
-		staff = "Staff",
-		rules = "Règles",
-		contribute = "Contribuer",
-		changelog = "Changements",
-		help_help = "<p align = 'center'><font size = '14'>Bienvenue à <T>#parkour!</T></font>\n\n<font size = '12'><J>Ton but est d'atteindre tous les points de sauvegarde pour finir la carte.</J></font></p>\n\n<font size = '11'><N>• Appuie sur <O>O</O>, écris <O>!op</O> ou clique sur le <O>bouton de configuration</O> pour ouvrir les <T>options</T>.\n• Appuie sur <O>P</O> ou clique sur la <O>main</O> en haut à droite pour voir les <T>pouvoirs</T>.\n• Appuie sur <O>L</O> ou écris <O>!lb</O> pour ouvrir le <T>classement</T>.\n• Utilise la touche <O>M</O> ou la touche <O>Suppr.</O> comme un raccourci pour <T>/mort</T>, tu peux personnaliser les touches dans les <J>Options</J>.\n• Pour en savoir plus à propos du <O>staff</O> et des <O>règles de parkour</O>, clique sur les pages <T>Staff</T> et <T>Règles</T>.\n• Clique <a href='event:discord'><o>ici</o></a> pour avoir le lien d'invitation Discord et <a href='event:map_submission'><o>ici</o></a> pour avoir le lien pour proposer des maps.\n• Utilise les fléches d'<o>en haut</o> et d'<o>en bas</o> si tu as besoin de scroller.\n\n<p align = 'center'><font size = '13'><T>Les contributions sont maintenant ouvertes ! Pour plus d'informations, clique sur la page <O>Contribuer</O> </T></font></p>",
-		help_staff = "<p align = 'center'><font size = '13'><r>INFORMATION: Le Staff de Parkour n'est pas le Staff de Transformice, ils n'ont aucun pouvoir sur le jeu en lui-même, seulement dans ce module.</r>\nLe Staff de Parkour s'assure que le module marche bien, avec le moins de problèmes possible et sont toujours disponibles pour aider les joueurs.</font></p>\nVous pouvez écrire <D>!staff</D> dans le chat pour voir la liste du Staff en ligne.\n\n<font color = '#E7342A'>Administrateurs:</font> Ils sont responsables de maintenir le module lui-même en ajoutant des mises à jour et en réparant les bugs.\n\n<font color = '#D0A9F0'>Managers des équipes:</font> Ils surveillent les modérateurs et les créateurs de cartes, surveillant s'ils font bien leur travail. Ils sont aussi responsable du recrutement des nouveaux membres du Staff.\n\n<font color = '#FFAAAA'>Modérateurs:</font> Ils font respecter les règles du module et punissent ceux qui les enfreignent.\n\n<font color = '#25C059'>Mappers:</font> Ils sont aussi responsable de vérifier, ajouter et de supprimer des cartes dans le module pour rendre vos parties plus agréables.",
-		help_rules = "<font size = '13'><B><J>Toutes Les Règles des Termes et des Conditions de Transformice s'appliquent aussi dans #parkour.</J></B></font>\n\nSi vous surprenez un joueur en train d'enfreindre les règles, chuchotez à un modérateur #parkour connecté. Si aucun modérateur n'est en ligne, signalez le joueur dans le serveur Discord.\nPour tous signalements, veuillez inclure : la communauté, le nom du salon, et le nom du joueur.\n• Ex: fr-#parkour10 Blank#3495 troll\nDes preuves, comme des vidéos et des GIFs aident et sont appréciés, mais pas nécessaires.\n\n<font size = '11'>• Aucun <font color = '#ef1111'>hack, glitch ou bugs</font> utilisé/abusé n'est pas autorisé dans les salons #parkour\n• <font color = '#ef1111'>Le farm VPN</font> est considéré comme <B>une violation</B> et n'est pas autorisé. <p align = 'center'><font color = '#cc2222' size = '12'><B>\nN'importe qui surprit en train d'enfreindre ces règles sera banni.</B></font></p>\n\n<font size = '12'>Transformice autorise le concept du troll. Cependant, <font color='#cc2222'><B>nous ne l'autorisons pas dans #parkour.</B></font></font>\n\n<p align = 'center'><J>Le troll est quand un joueur utilise ses pouvoirs ou ses objets d’inventaire pour intentionnellement empêcher les autres joueurs de finir la map.</j></p>\n• Le troll en revanche d'un autre troll <B>n'est pas une raison valable</B> et sera sanctionné.\n• Aider un joueur voulant faire la carte seule est aussi considéré comme du troll.\n• <J>Si un joueur veut réaliser la map sans aide, merci de le laisser libre de son choix et d'aider les autres joueurs</J>. Si un autre joueur a besoin d'aide au même point de sauvegarde qu'un autre qui n'en veut pas, vous pouvez aider les deux.\n\nSi un joueur est surpris en train de troller, il sera puni en fonction d’un système de temps. Notez que du troll répétitif peut amener à des sanctions de plus en plus sévères.",
-		help_contribute = "<font size='14'>\n<p align='center'>L'équipe de direction de parkour aime l'open-source car <t>cela aide la communauté</t>. Vous pouvez <o>voir</o> et <o>modifier</o> le code source sur <o><u><a href='event:github'>GitHub</a></u></o>.\n\nEntretenir le module est <t>strictement volontaire</t>, donc toute aide regardant le <t>développement</t>, <t>des signalements de bugs</t>, <t>des suggestions</t> et <t>la création de maps</t> est toujours <u>la bienvenue et apprécié</u>.\nVous pouvez <vp>signaler des bugs</vp> et <vp>faire des suggestions</vp> sur le <o><u><a href='event:discord'>Discord</a></u></o> et/ou <o><u><a href='event:github'>GitHub</a></u></o>.\nVous pouvez <vp>proposer des cartes</vp> sur le <o><u><a href='event:map_submission'>Forum</a></u></o>.\n\nEntretenir le module n'est pas cher, mais ce n'est pas non plus gratuit. Nous apprécierons si vous nous aidiez en <t>faisant un don</t> <o><u><a href='event:donate'>ici</a></u></o>.\n<u>Toutes les donations iront directement dans l'amélioration du module.</u></p>",
-		help_changelog = "<font size='13'><p align='center'><o>Version 2.10.0 - 17/04/2021</o></p>\n\n<font size='11'>• <font size='13'><b><j>TROIS</J></b> nouveaux titres Tranformice tout frais qui ne peuvent seulement être obtenus en jouant à <font color='#1A7EC9'><b>#parkour</b></font>!</font>\n• Deux nouveaux status ajoutés au profil.\n• Amélioration mineure de texte.",
-
-		-- Congratulation messages
-		reached_level = "<d>Bravo! Vous avez atteint le niveau <vp>%s</vp>. (<t>%ss</t>)",
-		finished = "<d><o>%s</o> a fini le parkour en <vp>%s</vp> secondes, <fc>félicitations!",
-		unlocked_power = "<ce><d>%s</d> a débloqué le pouvoir <vp>%s</vp>.",
-
-		-- Information messages
-		mod_apps = "<j>Les candidatures pour devenir modérateur de Parkour sont maintenant ouvertes! Rendez-vous sur cette page: <rose>%s",
-		staff_power = "<r>Le staff de parkour <b>n'a pas</b> de pouvoir en dehors du module.",
-		donate = "<vp>Tapez <b>!donate</b> si vous souhaitez faire un don pour ce module !",
-		paused_events = "<cep><b>[Attention!]</b> <n>Le module a atteint sa limite critique et est en pause.",
-		resumed_events = "<n2>Le module n'est plus en pause.",
-		welcome = "<n>Bienvenue dans <t>#parkour</t>!",
-		module_update = "<r><b>[Attention!]</b> <n>Le module va se réinitialiser dans <d>%02d:%02d</d>.",
-		leaderboard_loaded = "<j>Le tableau des scores a été chargé. Appuyer sur L pour l'ouvrir.",
-		kill_minutes = "<R>Tes pouvoirs ont été désactivés pour %s minutes.",
-		permbanned = "<r>Tu as été banni de #parkour définitevement.",
-		tempbanned = "<r>Tu as été banni de #parkour pendant %s minutes.",
-		forum_topic = "<rose>Pour plus d'informations sur le module, visite ce lien: %s",
-		report = "<j>Besoin de signaler un joueur? <t><b>/c Parkour#8558 .report Pseudo#0000</b></t>",
-
-		-- Easter Eggs
-		easter_egg_0  = "<ch>Le compte à rebours a commencé...",
-		easter_egg_1  = "<ch>Il reste moins de 24 heures !",
-		easter_egg_2  = "<ch>Wow, tu es en avance ! Tu es très excité(e) ?",
-		easter_egg_3  = "<ch>Une surprise t'attend...",
-		easter_egg_4  = "<ch>Tu sais ce qu'il va se passer...?",
-		easter_egg_5  = "<ch>L'horloge tourne...",
-		easter_egg_6  = "<ch>La surprise est proche !",
-		easter_egg_7  = "<ch>La fête va commencer...",
-		easter_egg_8  = "<ch>Regarde l'heure, est-ce le moment ?",
-		easter_egg_9  = "<ch>Fais attention, le temps passe...",
-		easter_egg_10 = "<ch>Assis-toi et relax, ce sera demain dans peu de temps !",
-		easter_egg_11 = "<ch>Allons dormir plus tôt, ça accélérera le temps !",
-		easter_egg_12 = "<ch>La patience est une vertue",
-		easter_egg_13 = "<ch>https://youtu.be/9jK-NcRmVcw",
-		double_maps = "<bv>Maps doubles Samedi (GMT+2) et tous les pouvoirs sont disponibles pour le semaine d'anniversaire de parkour!",
-		double_maps_start = "<rose>C'EST LA SEMAINE D'ANNIVERSAIRE DE PARKOUR! Les double maps et tous les pouvoirs ont été activés. Merci de jouer avec nous!",
-		double_maps_end = "<rose>La semaine d'anniversaire de parkour est terminée. Merci de jouer avec nous!",
-
-		-- Records
-		records_enabled = "<v>[#] <d>Le mode de records a été activé dans ce salon. Les statistiques ne compteront pas et les pouvoirs sont désactivés !\nTu peux trouver plus d'informations à propos des records sur <b>%s</b>",
-		records_admin = "<v>[#] <d>Tu es un administrateur de ce salon de records. Vous pouvez utiliser les commandes <b>!map</b>, <b>!pw</b> et <b>!time</b>.",
-		records_completed = "<v>[#] <d>Tu as complété la carte ! Si tu veux la refaire, ecrivez <b>!redo</b>.",
-		records_submit = "<v>[#] <d>Wow ! On dirait que tu as fait le temps le plus rapide dans ce salon. Si tu veux envoyez voter record, écris <b>!submit</b>.",
-		records_invalid_map = "<v>[#] <r>On dirait que cette carte n'est pas dans la rotation de parkour... Tu ne peux pas envoyer de records pour celle-ci!",
-		records_not_fastest = "<v>[#] <r>On dirait que tu n'es pas le joueur le plus rapide dans ce salon...",
-		records_already_submitted = "<v>[#] <r>Tu as déjà envoyé ton record pour cette carte!",
-		records_submitted = "<v>[#] <d>Ton record pour la carte <b>%s</b> a été envoyé.",
-
-		-- Miscellaneous
-		afk_popup = "\n<p align='center'><font size='30'><bv><b>VOUS ÊTES DÉSORMAIS AFK</b></bv>\nBOUGEZ POUR REAPPARAÎTRE</font>\n\n<font size='30'><u><t>Rappels:</t></u></font>\n\n<font size='15'><r>Les joueurs avec une ligne rouge au-dessus d'eux ne veulent pas d'aide!\nTroller/bloquer des joueurs est interdit dans parkour!<d>\nRejoins notre <cep><a href='event:discord'>serveur Discord</a></cep>!\nEnvie de contribuer au code? Viens voir notre <cep><a href='event:github'>GitHub</a></cep>\nTu as une bonne carte à nous proposer? Viens la poster sur notre <cep><a href='event:map_submission'>sujet de proposition de cartes</a></cep>\nJettes un oeil à notre <cep><a href='event:forum'>sujet officiel</a></cep> pour plus d'informations!\nSoutiens le module en faisant un <cep><a href='event:donate'>don!</a></cep>",
-		options = "<p align='center'><font size='20'>Options de Parkour</font></p>\n\nUtiliser le clavier <b>QWERTY</b> (désactiver si votre clavier est en <b>AZERTY</b>)\n\nUtiliser <b>M</b> comme raccourci pour <b>/mort</b> (désactiver pour <b>DEL</b>)\n\nAffiche le temps de recharge de vos compétences\n\nAffiche les boutons pour utiliser les compétences\n\nAffiche le bouton d'aide\n\nAffiche les annonces des cartes achevées\n\nAffichage d'un indicateur pour ne pas être aidé.",
-		cooldown = "<v>[#] <r>Attends quelques secondes avant de pouvoir recommencer.",
-		power_options = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'>Clavier <b>QWERTY</b>" ..
-						 "\n\n<b>Cacher</b> le nombre de cartes" ..
-						 "\n\n<b>Touche original</b>"),
-		unlock_power = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Complète <v>%s</v> maps" ..
-						"<font size='5'>\n\n</font>pour débloquer le pouvoir" ..
-						"<font size='5'>\n\n</font><v>%s</v>"),
-		upgrade_power = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Complète <v>%s</v> maps" ..
-						"<font size='5'>\n\n</font>pour améliorer le pouvoir" ..
-						"<font size='5'>\n\n</font><v>%s</v>"),
-		unlock_power_rank = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Rang <v>%s</v> requis" ..
-						"<font size='5'>\n\n</font>pour débloquer le pouvoir" ..
-						"<font size='5'>\n\n</font><v>%s</v>"),
-		upgrade_power_rank = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Rang <v>%s</v> requis" ..
-						"<font size='5'>\n\n</font>pour améliorer le pouvoir" ..
-						"<font size='5'>\n\n</font><v>%s</v>"),
-		maps_info = ("<p align='center'><font size='11' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
-					 "<font size='5'>\n\n</font>Maps complétées"),
-		overall_info = ("<p align='center'><font size='11' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
-						"<font size='5'>\n\n</font>Classement Global"),
-		weekly_info = ("<p align='center'><font size='11' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
-					   "<font size='5'>\n\n</font>Classement Hebdomadaire"),
-		badges = "<font size='14' face='Lucida Console,Liberation Mono,Courier New,Verdana'>Badges (%s): <a href='event:_help:badge'><j>[?]</j></a>",
-		private_maps = "<bl>Le nombre de cartes complétées de ce joueur est privé. <a href='event:_help:private_maps'><j>[?]</j></a></bl>\n",
-		profile = ("<font size='12' face='Lucida Console,Liberation Mono,Courier New,Verdana'>%s%s %s\n\n" ..
-					"Position dans le classement global: <b><v>%s</v></b>\n\n" ..
-					"Position dans le classement hebdomadaire: <b><v>%s</v></b>\n\n%s"),
-		map_count = "Nombre de maps complétées: <b><v>%s</v> / <a href='event:_help:yellow_maps'><j>%s</j></a> / <a href='event:_help:red_maps'><r>%s</r></a></b>",
-		title_count = ("<b><j>«!»</j></b> Maps terminées : <b><a href='event:_help:map_count_title'><v>%s</v></a></b>\n\n" ..
-					"<b><j>«!»</j></b> Checkpoints atteints : <b><a href='event:_help:checkpoint_count_title'><v>%s</v></a></b>"),
-		help_badge = "Les badges sont des accomplissements que peuvent obtenir les joueurs. Clique sur un badge pour voir sa description.",
-		help_private_maps = "Ce joueur ne souhaite pas partager son nombre de maps complétées ! Tu peux également le cacher sur ton profil.",
-		help_yellow_maps = "Les cartes en jaune sont les cartes complétées cette semaine.",
-		help_red_maps = "Les cartes en rouge ont été complétées cette heure-ci.",
-		help_map_count_title = "Tu peux recevoir des titres de <b>Transformice</b> en complétant des maps parkour !",
-		help_checkpoint_count_title = "Tu peux recevoir des titres de <b>Transformice</b> en atteignant tous les checkpoints dans les maps parkour !",
-		help_badge_1 = "Ce joueur a été un membre du staff de parkour.",
-		help_badge_2 = "Ce joueur est ou était sur la page 1 du classement global.",
-		help_badge_3 = "Ce joueur est ou était sur la page 2 du classement global.",
-		help_badge_4 = "Ce joueur est ou était sur la page 3 du classement global.",
-		help_badge_5 = "Ce joueur est ou était sur la page 4 du classement global.",
-		help_badge_6 = "Ce joueur est ou était sur la page 5 du classement global.",
-		help_badge_7 = "Ce joueur a été sur le podium à la fin d'un classement hebdomadaire.",
-		help_badge_8 = "Ce joueur a un record de 30 cartes par heure.",
-		help_badge_9 = "Ce joueur a un record de 35 cartes par heure.",
-		help_badge_10 = "Ce joueur a un record de 40 cartes par heure.",
-		help_badge_11 = "Ce joueur a un record de 45 cartes par heure.",
-		help_badge_12 = "Ce joueur a un record de 50 cartes par heure.",
-		help_badge_13 = "Ce joueur a un record de 55 cartes par heure.",
-		help_badge_14 = "Ce joueur a vérifié son compte discord sur le discord officiel de parkour (écris <b>!discord</b>).",
-		help_badge_15 = "Ce joueur a obtenu le temps le plus rapide sur 1 carte.",
-		help_badge_16 = "Ce joueur a obtenu le temps le plus rapide sur 5 cartes.",
-		help_badge_17 = "Ce joueur a obtenu le temps le plus rapide sur 10 cartes.",
-		help_badge_18 = "Ce joueur a obtenu le temps le plus rapide sur 15 cartes.",
-		help_badge_19 = "Ce joueur a obtenu le temps le plus rapide sur 20 cartes.",
-		help_badge_20 = "Ce joueur a obtenu le temps le plus rapide sur 25 cartes.",
-		help_badge_21 = "Ce joueur a obtenu le temps le plus rapide sur 30 cartes.",
-		help_badge_22 = "Ce joueur a obtenu le temps le plus rapide sur 35 cartes.",
-		help_badge_23 = "Ce joueur a obtenu le temps le plus rapide sur 40 cartes.",
-		make_public = "Rendre publique",
-		make_private = "Rendre privé",
-		moderators = "Modérateurs",
-		mappers = "Mappers",
-		managers = "Manageurs",
-		administrators = "Administrateurs",
-		close = "Fermer",
-		cant_load_bot_profile = "<v>[#] <r>Tu ne peux pas voir le profile de ce robot car #parkour l'utilise intérieurement pour faire fonctionner le module correctement.",
-		cant_load_profile = "<v>[#] <r>Le joueur <b>%s</b> semble être hors ligne ou n'existe pas.",
-		like_map = "Aimez-vous cette carte?",
-		yes = "Oui",
-		no = "Non",
-		idk = "Je ne sais pas",
-		unknown = "Inconnu",
-		powers = "Pouvoirs",
-		press = "<vp>Appuyer sur %s",
-		click = "<vp>Clique gauche",
-		ranking_pos = "Classement #%s",
-		completed_maps = "<p align='center'><BV><B>Cartes complétées: %s</B></p></BV>",
-		leaderboard = "Classement",
-		position = "<V><p align=\"center\">Position",
-		username = "<V><p align=\"center\">Pseudo",
-		community = "<V><p align=\"center\">Communauté",
-		completed = "<V><p align=\"center\">Cartes complétées",
-		overall_lb = "Permanent",
-		weekly_lb = "Hebdomadaire",
-		new_lang = "<v>[#] <d>Langue changée vers Français",
-
-		-- Power names
-		balloon = "Ballon",
-		masterBalloon = "Ballon Maître",
-		bubble = "Bulle",
-		fly = "Voler",
-		snowball = "Boule de neige",
-		speed = "Accélération",
-		teleport = "Téléportation",
-		smallbox = "Petite boîte",
-		cloud = "Nuage",
-		rip = "Tombe",
-		choco = "Planche de chocolat",
-		bigBox = "Grande boîte",
-		trampoline = "Trampoline",
-		toilet = "Toilettes",
-		pig = "Cochon",
-		sink = "Evier",
-		bathtub = "Baignoire",
-		campfire = "Feu de Camp",
-		chair = "Chaise",
-	}
-	--[[ End of file translations/parkour/fr.lua ]]--
 	--[[ File translations/parkour/hu.lua ]]--
 	translations.hu = {
 		name = "hu",
@@ -3358,392 +3551,199 @@ local function initialize_parkour() -- so it uses less space after building
 		chair = "Szék",
 	}
 	--[[ End of file translations/parkour/hu.lua ]]--
-	--[[ File translations/parkour/en.lua ]]--
-	translations.en = {
-		name = "en",
-		fullname = "English",
+	--[[ File translations/parkour/fr.lua ]]--
+	translations.fr = {
+		name = "fr",
+		fullname = "Français",
 
 		-- Error messages
-		corrupt_map = "<r>Corrupt map. Loading another.",
-		corrupt_map_vanilla = "<r>[ERROR] <n>Can not get information of this map.",
-		corrupt_map_mouse_start = "<r>[ERROR] <n>This map needs to have a start position (mouse spawn point).",
-		corrupt_map_needing_chair = "<r>[ERROR] <n>The map needs to have the end chair.",
-		corrupt_map_missing_checkpoints = "<r>[ERROR] <n>The map needs to have at least one checkpoint (yellow nail).",
-		corrupt_data = "<r>Unfortunately, your data was corrupt and has been reset.",
-		min_players = "<r>To save your data, there must be at least 4 unique players in the room. <bl>[%s/%s]",
-		tribe_house = "<r>Data will not be saved in tribehouses.",
-		invalid_syntax = "<r>Invalid syntax.",
-		code_error = "<r>An error appeared: <bl>%s-%s-%s %s",
-		emergency_mode = "<r>Initiating emergency shutdown, no new players allowed. Please go to another #parkour room.",
-		leaderboard_not_loaded = "<r>The leaderboard has not been loaded yet. Wait a minute.",
-		max_power_keys = "<v>[#] <r>You can only have at most %s powers in the same key.",
+		corrupt_map = "<r>Carte non opérationnelle. Chargement d'une autre.",
+		corrupt_map_vanilla = "<r>[ERROR] <n>Impossible de récolter les informations de cette carte.",
+		corrupt_map_mouse_start = "<r>[ERROR] <n>Cette carte a besoin d'un point d'apparition (pour les souris).",
+		corrupt_map_needing_chair = "<r>[ERROR] <n>La carte a besoin d'une chaise d'arrivée (point final).",
+		corrupt_map_missing_checkpoints = "<r>[ERROR] <n>La carte a besoin d'au moins un point de sauvegarde (étoiles jaunes).",
+		corrupt_data = "<r>Malheureusement, tes données ont été corrompues et ont été effacées.",
+		min_players = "<r>Pour sauvegarder les données, il doit y avoir au moins 4 souris dans le salon. <bl>[%s/%s]",
+		tribe_house = "<r>Les données ne sont pas sauvegardées dans les maisons de tribu.",
+		invalid_syntax = "<r>Syntaxe invalide.",
+		code_error = "<r>Une erreur est survenue: <bl>%s-%s-%s %s",
+		emergency_mode = "<r>Mise en place du blocage d'urgence, aucun nouveau joueur ne peut rejoindre. Merci d'aller dans un autre salon #parkour.",
+		leaderboard_not_loaded = "<r>Le tableau des scores n'a pas été encore chargé. Attendez une minute.",
+		max_power_keys = "<v>[#] <r>Vous pouvez avoir maximum %s pouvoirs sur la même touche.",
 
 		-- Help window
-		help = "Help",
+		help = "Aide",
 		staff = "Staff",
-		rules = "Rules",
-		contribute = "Contribute",
-		changelog = "News",
-		help_help = "<p align = 'center'><font size = '14'>Welcome to <T>#parkour!</T></font></p>\n<font size = '12'><p align='center'><J>Your goal is to reach all the checkpoints until you complete the map.</J></p>\n\n<N>• Press <O>O</O>, type <O>!op</O> or click the <O>configuration button</O> to open the <T>options menu</T>.\n• Press <O>P</O> or click the <O>hand icon</O> at the top-right to open the <T>powers menu</T>.\n• Press <O>L</O> or type <O>!lb</O> to open the <T>leaderboard</T>.\n• Press the <O>M</O> or <O>Delete</O> key to <T>/mort</T>, you can toggle the keys in the <J>Options</J> menu.\n• To know more about our <O>staff</O> and the <O>rules of parkour</O>, click on the <T>Staff</T> and <T>Rules</T> tab respectively.\n• Click <a href='event:discord'><o>here</o></a> to get the discord invite link and <a href='event:map_submission'><o>here</o></a> to get the map submission topic link.\n• Use <o>up</o> and <o>down</o> arrow keys when you need to scroll.\n\n<p align = 'center'><font size = '13'><T>Contributions are now open! For further details, click on the <O>Contribute</O> tab!</T></font></p>",
-		help_staff = "<p align = 'center'><font size = '13'><r>DISCLAIMER: Parkour staff ARE NOT Transformice staff and DO NOT have any power in the game itself, only within the module.</r>\nParkour staff ensure that the module runs smoothly with minimal issues, and are always available to assist players whenever necessary.</font></p>\nYou can type <D>!staff</D> in the chat to see the staff list.\n\n<font color = '#E7342A'>Administrators:</font> They are responsible for maintaining the module itself by adding new updates and fixing bugs.\n\n<font color = '#D0A9F0'>Team Managers:</font> They oversee the Moderator and Mapper teams, making sure they are performing their jobs well. They are also responsible for recruiting new members to the staff team.\n\n<font color = '#FFAAAA'>Moderators:</font> They are responsible for enforcing the rules of the module and punishing individuals who do not follow them.\n\n<font color = '#25C059'>Mappers:</font> They are responsible for reviewing, adding, and removing maps within the module to ensure that you have an enjoyable gameplay.",
-		help_rules = "<font size = '13'><B><J>All rules in the Transformice Terms and Conditions also apply to #parkour</J></B></font>\n\nIf you find any player breaking these rules, whisper the parkour mods in-game. If no mods are online, then it is recommended to report it in the discord server.\nWhen reporting, please include the server, room name, and player name.\n• Ex: en-#parkour10 Blank#3495 trolling\nEvidence, such as screenshots, videos and gifs are helpful and appreciated, but not necessary.\n\n<font size = '11'>• No <font color = '#ef1111'>hacks, glitches or bugs</font> are to be used in #parkour rooms\n• <font color = '#ef1111'>VPN farming</font> will be considered an <B>exploit</B> and is not allowed. <p align = 'center'><font color = '#cc2222' size = '12'><B>\nAnyone caught breaking these rules will be immediately banned.</B></font></p>\n\n<font size = '12'>Transformice allows the concept of trolling. However, <font color='#cc2222'><B>we will not allow it in parkour.</B></font></font>\n\n<p align = 'center'><J>Trolling is when a player intentionally uses their powers or consumables to prevent other players from finishing the map.</j></p>\n• Revenge trolling is <B>not a valid reason</B> to troll someone and you will still be punished.\n• Forcing help onto players trying to solo the map and refusing to stop when asked is also considered trolling.\n• <J>If a player does not want help or prefers to solo a map, please try your best to help other players</J>. However if another player needs help in the same checkpoint as the solo player, you can help them [both].\n\nIf a player is caught trolling, they will be punished on a time basis. Note that repeated trolling will lead to longer and more severe punishments.",
-		help_contribute = "<font size='14'>\n<p align='center'>The parkour management team loves open source code because it <t>helps the community</t>. You can <o>view</o> and <o>modify</o> the source code on <o><u><a href='event:github'>GitHub</a></u></o>.\n\nMaintaining the module is <t>strictly voluntary</t>, so any help regarding <t>code</t>, <t>bug reports</t>, <t>suggestions</t> and <t>creating maps</t> is always <u>welcome and appreciated</u>.\nYou can <vp>report bugs</vp> and <vp>give suggestions</vp> on <o><u><a href='event:discord'>Discord</a></u></o> and/or <o><u><a href='event:github'>GitHub</a></u></o>.\nYou can <vp>submit your maps</vp> in our <o><u><a href='event:map_submission'>Forum Thread</a></u></o>.\n\nMaintaining parkour is not expensive, but it is not free either. We'd love if you could help us by <t>donating any amount</t> <o><u><a href='event:donate'>here</a></u></o>.\n<u>All donations will go towards improving the module.</u></p>",
-		help_changelog = "<font size='13'><p align='center'><o>Version 2.10.0 - 17/04/2021</o></p>\n\n<font size='11'>• <font size='13'><b><j>THREE</J></b> brand new Transformice titles that can only be unlocked by playing <font color='#1A7EC9'><b>#parkour</b></font>!</font>\n• Two new statuses added to the profile.\n• Minor text adjustments.",
+		rules = "Règles",
+		contribute = "Contribuer",
+		changelog = "Changements",
+		help_help = "<p align = 'center'><font size = '14'>Bienvenue à <T>#parkour!</T></font>\n\n<font size = '12'><J>Ton but est d'atteindre tous les points de sauvegarde pour finir la carte.</J></font></p>\n\n<font size = '11'><N>• Appuie sur <O>O</O>, écris <O>!op</O> ou clique sur le <O>bouton de configuration</O> pour ouvrir les <T>options</T>.\n• Appuie sur <O>P</O> ou clique sur la <O>main</O> en haut à droite pour voir les <T>pouvoirs</T>.\n• Appuie sur <O>L</O> ou écris <O>!lb</O> pour ouvrir le <T>classement</T>.\n• Utilise la touche <O>M</O> ou la touche <O>Suppr.</O> comme un raccourci pour <T>/mort</T>, tu peux personnaliser les touches dans les <J>Options</J>.\n• Pour en savoir plus à propos du <O>staff</O> et des <O>règles de parkour</O>, clique sur les pages <T>Staff</T> et <T>Règles</T>.\n• Clique <a href='event:discord'><o>ici</o></a> pour avoir le lien d'invitation Discord et <a href='event:map_submission'><o>ici</o></a> pour avoir le lien pour proposer des maps.\n• Utilise les fléches d'<o>en haut</o> et d'<o>en bas</o> si tu as besoin de scroller.\n\n<p align = 'center'><font size = '13'><T>Les contributions sont maintenant ouvertes ! Pour plus d'informations, clique sur la page <O>Contribuer</O> </T></font></p>",
+		help_staff = "<p align = 'center'><font size = '13'><r>INFORMATION: Le Staff de Parkour n'est pas le Staff de Transformice, ils n'ont aucun pouvoir sur le jeu en lui-même, seulement dans ce module.</r>\nLe Staff de Parkour s'assure que le module marche bien, avec le moins de problèmes possible et sont toujours disponibles pour aider les joueurs.</font></p>\nVous pouvez écrire <D>!staff</D> dans le chat pour voir la liste du Staff en ligne.\n\n<font color = '#E7342A'>Administrateurs:</font> Ils sont responsables de maintenir le module lui-même en ajoutant des mises à jour et en réparant les bugs.\n\n<font color = '#D0A9F0'>Managers des équipes:</font> Ils surveillent les modérateurs et les créateurs de cartes, surveillant s'ils font bien leur travail. Ils sont aussi responsable du recrutement des nouveaux membres du Staff.\n\n<font color = '#FFAAAA'>Modérateurs:</font> Ils font respecter les règles du module et punissent ceux qui les enfreignent.\n\n<font color = '#25C059'>Mappers:</font> Ils sont aussi responsable de vérifier, ajouter et de supprimer des cartes dans le module pour rendre vos parties plus agréables.",
+		help_rules = "<font size = '13'><B><J>Toutes Les Règles des Termes et des Conditions de Transformice s'appliquent aussi dans #parkour.</J></B></font>\n\nSi vous surprenez un joueur en train d'enfreindre les règles, chuchotez à un modérateur #parkour connecté. Si aucun modérateur n'est en ligne, signalez le joueur dans le serveur Discord.\nPour tous signalements, veuillez inclure : la communauté, le nom du salon, et le nom du joueur.\n• Ex: fr-#parkour10 Blank#3495 troll\nDes preuves, comme des vidéos et des GIFs aident et sont appréciés, mais pas nécessaires.\n\n<font size = '11'>• Aucun <font color = '#ef1111'>hack, glitch ou bugs</font> utilisé/abusé n'est pas autorisé dans les salons #parkour\n• <font color = '#ef1111'>Le farm VPN</font> est considéré comme <B>une violation</B> et n'est pas autorisé. <p align = 'center'><font color = '#cc2222' size = '12'><B>\nN'importe qui surprit en train d'enfreindre ces règles sera banni.</B></font></p>\n\n<font size = '12'>Transformice autorise le concept du troll. Cependant, <font color='#cc2222'><B>nous ne l'autorisons pas dans #parkour.</B></font></font>\n\n<p align = 'center'><J>Le troll est quand un joueur utilise ses pouvoirs ou ses objets d’inventaire pour intentionnellement empêcher les autres joueurs de finir la map.</j></p>\n• Le troll en revanche d'un autre troll <B>n'est pas une raison valable</B> et sera sanctionné.\n• Aider un joueur voulant faire la carte seule est aussi considéré comme du troll.\n• <J>Si un joueur veut réaliser la map sans aide, merci de le laisser libre de son choix et d'aider les autres joueurs</J>. Si un autre joueur a besoin d'aide au même point de sauvegarde qu'un autre qui n'en veut pas, vous pouvez aider les deux.\n\nSi un joueur est surpris en train de troller, il sera puni en fonction d’un système de temps. Notez que du troll répétitif peut amener à des sanctions de plus en plus sévères.",
+		help_contribute = "<font size='14'>\n<p align='center'>L'équipe de direction de parkour aime l'open-source car <t>cela aide la communauté</t>. Vous pouvez <o>voir</o> et <o>modifier</o> le code source sur <o><u><a href='event:github'>GitHub</a></u></o>.\n\nEntretenir le module est <t>strictement volontaire</t>, donc toute aide regardant le <t>développement</t>, <t>des signalements de bugs</t>, <t>des suggestions</t> et <t>la création de maps</t> est toujours <u>la bienvenue et apprécié</u>.\nVous pouvez <vp>signaler des bugs</vp> et <vp>faire des suggestions</vp> sur le <o><u><a href='event:discord'>Discord</a></u></o> et/ou <o><u><a href='event:github'>GitHub</a></u></o>.\nVous pouvez <vp>proposer des cartes</vp> sur le <o><u><a href='event:map_submission'>Forum</a></u></o>.\n\nEntretenir le module n'est pas cher, mais ce n'est pas non plus gratuit. Nous apprécierons si vous nous aidiez en <t>faisant un don</t> <o><u><a href='event:donate'>ici</a></u></o>.\n<u>Toutes les donations iront directement dans l'amélioration du module.</u></p>",
+		help_changelog = "<font size='13'><p align='center'><o>Version 2.10.0 - 17/04/2021</o></p>\n\n<font size='11'>• <font size='13'><b><j>TROIS</J></b> nouveaux titres Tranformice tout frais qui ne peuvent seulement être obtenus en jouant à <font color='#1A7EC9'><b>#parkour</b></font>!</font>\n• Deux nouveaux status ajoutés au profil.\n• Amélioration mineure de texte.",
 
 		-- Congratulation messages
-		reached_level = "<d>Congratulations! You've reached level <vp>%s</vp>. (<t>%ss</t>)",
-		finished = "<d><o>%s</o> finished the parkour in <vp>%s</vp> seconds, <fc>congratulations!",
-		unlocked_power = "<ce><d>%s</d> unlocked the <vp>%s</vp> power.",
+		reached_level = "<d>Bravo! Vous avez atteint le niveau <vp>%s</vp>. (<t>%ss</t>)",
+		finished = "<d><o>%s</o> a fini le parkour en <vp>%s</vp> secondes, <fc>félicitations!",
+		unlocked_power = "<ce><d>%s</d> a débloqué le pouvoir <vp>%s</vp>.",
 
 		-- Information messages
-		mod_apps = "<j>Parkour moderator applications are now open! Use this link: <rose>%s",
-		staff_power = "<p align='center'><font size='12'><r>Parkour staff <b>do not</b> have any power outside of #parkour rooms.",
-		donate = "<vp>Type <b>!donate</b> if you would like to donate for this module!",
-		paused_events = "<cep><b>[Warning!]</b> <n>The module has reached it's critical limit and is being paused.",
-		resumed_events = "<n2>The module has been resumed.",
-		welcome = "<n>Welcome to <t>#parkour</t>!",
-		module_update = "<r><b>[Warning!]</b> <n>The module will update in <d>%02d:%02d</d>.",
-		leaderboard_loaded = "<j>The leaderboard has been loaded. Press L to open it.",
-		kill_minutes = "<R>Your powers have been disabled for %s minutes.",
-		permbanned = "<r>You have been permanently banned from #parkour.",
-		tempbanned = "<r>You have been banned from #parkour for %s minutes.",
-		forum_topic = "<rose>For more information about the module visit this link: %s",
-		report = "<j>Want to report a parkour player? <t><b>/c Parkour#8558 .report Username#0000</b></t>",
+		mod_apps = "<j>Les candidatures pour devenir modérateur de Parkour sont maintenant ouvertes! Rendez-vous sur cette page: <rose>%s",
+		staff_power = "<r>Le staff de parkour <b>n'a pas</b> de pouvoir en dehors du module.",
+		donate = "<vp>Tapez <b>!donate</b> si vous souhaitez faire un don pour ce module !",
+		paused_events = "<cep><b>[Attention!]</b> <n>Le module a atteint sa limite critique et est en pause.",
+		resumed_events = "<n2>Le module n'est plus en pause.",
+		welcome = "<n>Bienvenue dans <t>#parkour</t>!",
+		module_update = "<r><b>[Attention!]</b> <n>Le module va se réinitialiser dans <d>%02d:%02d</d>.",
+		leaderboard_loaded = "<j>Le tableau des scores a été chargé. Appuyer sur L pour l'ouvrir.",
+		kill_minutes = "<R>Tes pouvoirs ont été désactivés pour %s minutes.",
+		permbanned = "<r>Tu as été banni de #parkour définitevement.",
+		tempbanned = "<r>Tu as été banni de #parkour pendant %s minutes.",
+		forum_topic = "<rose>Pour plus d'informations sur le module, visite ce lien: %s",
+		report = "<j>Besoin de signaler un joueur? <t><b>/c Parkour#8558 .report Pseudo#0000</b></t>",
 
 		-- Easter Eggs
-		easter_egg_0  = "<ch>Finally the countdown begins...",
-		easter_egg_1  = "<ch>Less than 24 hours remaining!",
-		easter_egg_2  = "<ch>Woah, you're quite early! Aren't you too excited?",
-		easter_egg_3  = "<ch>A surprise is waiting...",
-		easter_egg_4  = "<ch>Do you know what's about to happen...?",
-		easter_egg_5  = "<ch>The clock keeps ticking...",
-		easter_egg_6  = "<ch>The time is near!",
-		easter_egg_7  = "<ch>The party is about to begin...",
-		easter_egg_8  = "<ch>Check your clock, is it time yet?",
-		easter_egg_9  = "<ch>Be careful, time is passing...",
-		easter_egg_10 = "<ch>Just sit back and relax, it'll be tomorrow in no time!",
-		easter_egg_11 = "<ch>Let's go to bed early, it'll make the time go faster!",
-		easter_egg_12 = "<ch>Patience is a virtue",
+		easter_egg_0  = "<ch>Le compte à rebours a commencé...",
+		easter_egg_1  = "<ch>Il reste moins de 24 heures !",
+		easter_egg_2  = "<ch>Wow, tu es en avance ! Tu es très excité(e) ?",
+		easter_egg_3  = "<ch>Une surprise t'attend...",
+		easter_egg_4  = "<ch>Tu sais ce qu'il va se passer...?",
+		easter_egg_5  = "<ch>L'horloge tourne...",
+		easter_egg_6  = "<ch>La surprise est proche !",
+		easter_egg_7  = "<ch>La fête va commencer...",
+		easter_egg_8  = "<ch>Regarde l'heure, est-ce le moment ?",
+		easter_egg_9  = "<ch>Fais attention, le temps passe...",
+		easter_egg_10 = "<ch>Assis-toi et relax, ce sera demain dans peu de temps !",
+		easter_egg_11 = "<ch>Allons dormir plus tôt, ça accélérera le temps !",
+		easter_egg_12 = "<ch>La patience est une vertue",
 		easter_egg_13 = "<ch>https://youtu.be/9jK-NcRmVcw",
-		double_maps = "<bv>Double maps on Saturday (GMT+2) and all powers are available for parkour's birthday week!",
-		double_maps_start = "<rose>IT'S PARKOUR'S BIRTHDAY WEEK! Double maps and all powers have been activated. Thank you for all the support and for playing this module!",
-		double_maps_end = "<rose>Parkour's birthday week has ended. Thank you for all the support and for playing this module!",
+		double_maps = "<bv>Maps doubles Samedi (GMT+2) et tous les pouvoirs sont disponibles pour le semaine d'anniversaire de parkour!",
+		double_maps_start = "<rose>C'EST LA SEMAINE D'ANNIVERSAIRE DE PARKOUR! Les double maps et tous les pouvoirs ont été activés. Merci de jouer avec nous!",
+		double_maps_end = "<rose>La semaine d'anniversaire de parkour est terminée. Merci de jouer avec nous!",
 
 		-- Records
-		records_enabled = "<v>[#] <d>Records mode is enabled in this room. Stats won't count and powers aren't enabled!\nYou can find more information about records in <b>%s</b>",
-		records_admin = "<v>[#] <d>You're an administrator of this records room. You can use the commands <b>!map</b>, <b>!setcp</b>, <b>!pw</b> and <b>!time</b>.",
-		records_completed = "<v>[#] <d>You've completed the map! If you would like to re-do it, type <b>!redo</b>.",
-		records_submit = "<v>[#] <d>Wow! Looks like you had the fastest time in the room. If you would like to submit your record, type <b>!submit</b>.",
-		records_invalid_map = "<v>[#] <r>Looks like this map is not in parkour rotation... You can't submit a record for it!",
-		records_not_fastest = "<v>[#] <r>Looks like you're not the fastest player in the room...",
-		records_already_submitted = "<v>[#] <r>You already submitted your record for this map!",
-		records_submitted = "<v>[#] <d>Your record for the map <b>%s</b> has been submitted.",
+		records_enabled = "<v>[#] <d>Le mode de records a été activé dans ce salon. Les statistiques ne compteront pas et les pouvoirs sont désactivés !\nTu peux trouver plus d'informations à propos des records sur <b>%s</b>",
+		records_admin = "<v>[#] <d>Tu es un administrateur de ce salon de records. Vous pouvez utiliser les commandes <b>!map</b>, <b>!pw</b> et <b>!time</b>.",
+		records_completed = "<v>[#] <d>Tu as complété la carte ! Si tu veux la refaire, ecrivez <b>!redo</b>.",
+		records_submit = "<v>[#] <d>Wow ! On dirait que tu as fait le temps le plus rapide dans ce salon. Si tu veux envoyez voter record, écris <b>!submit</b>.",
+		records_invalid_map = "<v>[#] <r>On dirait que cette carte n'est pas dans la rotation de parkour... Tu ne peux pas envoyer de records pour celle-ci!",
+		records_not_fastest = "<v>[#] <r>On dirait que tu n'es pas le joueur le plus rapide dans ce salon...",
+		records_already_submitted = "<v>[#] <r>Tu as déjà envoyé ton record pour cette carte!",
+		records_submitted = "<v>[#] <d>Ton record pour la carte <b>%s</b> a été envoyé.",
 
 		-- Miscellaneous
-		afk_popup = "\n<p align='center'><font size='30'><bv><b>YOU'RE ON AFK MODE</b></bv>\nMOVE TO RESPAWN</font>\n\n<font size='30'><u><t>Reminders:</t></u></font>\n\n<font size='15'><r>Players with a red line over them don't want help!\nTrolling/blocking other players in parkour is NOT allowed!<d>\nJoin our <cep><a href='event:discord'>discord server</a></cep>!\nWant to contribute with code? See our <cep><a href='event:github'>github repository</a></cep>\nDo you have a good map to submit? Post it in our <cep><a href='event:map_submission'>map submission topic</a></cep>\nCheck our <cep><a href='event:forum'>official topic</a></cep> for more information!\nSupport us by <cep><a href='event:donate'>donating!</a></cep>",
-		options = "<p align='center'><font size='20'>Parkour Options</font></p>\n\nUse <b>QWERTY</b> keyboard (disable if <b>AZERTY</b>)\n\nUse <b>M</b> hotkey for <b>/mort</b> (disable for <b>DEL</b>)\n\nShow your power cooldowns\n\nShow powers button\n\nShow help button\n\nShow map completion announcements\n\nShow no help symbol",
-		cooldown = "<v>[#] <r>Wait a few seconds before doing that again.",
-		power_options = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><b>QWERTY</b> keyboard" ..
-						 "\n\n<b>Hide</b> map count" ..
-						 "\n\nUse <b>default key</b>"),
-		unlock_power = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Complete <v>%s</v> maps" ..
-						"<font size='5'>\n\n</font>to unlock" ..
+		afk_popup = "\n<p align='center'><font size='30'><bv><b>VOUS ÊTES DÉSORMAIS AFK</b></bv>\nBOUGEZ POUR REAPPARAÎTRE</font>\n\n<font size='30'><u><t>Rappels:</t></u></font>\n\n<font size='15'><r>Les joueurs avec une ligne rouge au-dessus d'eux ne veulent pas d'aide!\nTroller/bloquer des joueurs est interdit dans parkour!<d>\nRejoins notre <cep><a href='event:discord'>serveur Discord</a></cep>!\nEnvie de contribuer au code? Viens voir notre <cep><a href='event:github'>GitHub</a></cep>\nTu as une bonne carte à nous proposer? Viens la poster sur notre <cep><a href='event:map_submission'>sujet de proposition de cartes</a></cep>\nJettes un oeil à notre <cep><a href='event:forum'>sujet officiel</a></cep> pour plus d'informations!\nSoutiens le module en faisant un <cep><a href='event:donate'>don!</a></cep>",
+		options = "<p align='center'><font size='20'>Options de Parkour</font></p>\n\nUtiliser le clavier <b>QWERTY</b> (désactiver si votre clavier est en <b>AZERTY</b>)\n\nUtiliser <b>M</b> comme raccourci pour <b>/mort</b> (désactiver pour <b>DEL</b>)\n\nAffiche le temps de recharge de vos compétences\n\nAffiche les boutons pour utiliser les compétences\n\nAffiche le bouton d'aide\n\nAffiche les annonces des cartes achevées\n\nAffichage d'un indicateur pour ne pas être aidé.",
+		cooldown = "<v>[#] <r>Attends quelques secondes avant de pouvoir recommencer.",
+		power_options = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'>Clavier <b>QWERTY</b>" ..
+						 "\n\n<b>Cacher</b> le nombre de cartes" ..
+						 "\n\n<b>Touche original</b>"),
+		unlock_power = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Complète <v>%s</v> maps" ..
+						"<font size='5'>\n\n</font>pour débloquer le pouvoir" ..
 						"<font size='5'>\n\n</font><v>%s</v>"),
-		upgrade_power = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Complete <v>%s</v> maps" ..
-						"<font size='5'>\n\n</font>to upgrade to" ..
+		upgrade_power = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Complète <v>%s</v> maps" ..
+						"<font size='5'>\n\n</font>pour améliorer le pouvoir" ..
 						"<font size='5'>\n\n</font><v>%s</v>"),
-		unlock_power_rank = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Rank <v>%s</v>" ..
-						"<font size='5'>\n\n</font>to unlock" ..
+		unlock_power_rank = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Rang <v>%s</v> requis" ..
+						"<font size='5'>\n\n</font>pour débloquer le pouvoir" ..
 						"<font size='5'>\n\n</font><v>%s</v>"),
-		upgrade_power_rank = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Rank <v>%s</v>" ..
-						"<font size='5'>\n\n</font>to upgrade to" ..
+		upgrade_power_rank = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Rang <v>%s</v> requis" ..
+						"<font size='5'>\n\n</font>pour améliorer le pouvoir" ..
 						"<font size='5'>\n\n</font><v>%s</v>"),
-		maps_info = ("<p align='center'><font size='13' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
-					 "<font size='5'>\n\n</font>Completed Maps"),
-		overall_info = ("<p align='center'><font size='13' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
-						"<font size='5'>\n\n</font>Overall Leaderboard"),
-		weekly_info = ("<p align='center'><font size='13' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
-					   "<font size='5'>\n\n</font>Weekly Leaderboard"),
+		maps_info = ("<p align='center'><font size='11' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
+					 "<font size='5'>\n\n</font>Maps complétées"),
+		overall_info = ("<p align='center'><font size='11' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
+						"<font size='5'>\n\n</font>Classement Global"),
+		weekly_info = ("<p align='center'><font size='11' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
+					   "<font size='5'>\n\n</font>Classement Hebdomadaire"),
 		badges = "<font size='14' face='Lucida Console,Liberation Mono,Courier New,Verdana'>Badges (%s): <a href='event:_help:badge'><j>[?]</j></a>",
-		private_maps = "<bl>This player's map count is private. <a href='event:_help:private_maps'><j>[?]</j></a></bl>\n",
+		private_maps = "<bl>Le nombre de cartes complétées de ce joueur est privé. <a href='event:_help:private_maps'><j>[?]</j></a></bl>\n",
 		profile = ("<font size='12' face='Lucida Console,Liberation Mono,Courier New,Verdana'>%s%s %s\n\n" ..
-					"Overall leaderboard position: <b><v>%s</v></b>\n\n" ..
-					"Weekly leaderboard position: <b><v>%s</v></b>\n\n%s"),
-		map_count = "Map count: <b><v>%s</v> / <a href='event:_help:yellow_maps'><j>%s</j></a> / <a href='event:_help:red_maps'><r>%s</r></a></b>",
-		title_count = ("<b><j>«!»</j></b> Finished maps: <b><a href='event:_help:map_count_title'><v>%s</v></a></b>\n\n" ..
-					"<b><j>«!»</j></b> Collected checkpoints: <b><a href='event:_help:checkpoint_count_title'><v>%s</v></a></b>"),
-		help_badge = "Badges are accomplishments a player can get. Click over them to see their description.",
-		help_private_maps = "This player doesn't like to share their map count publicly! You can hide them too in your profile.",
-		help_yellow_maps = "Maps in yellow are the maps completed this week.",
-		help_red_maps = "Maps in red are the maps completed in the past hour.",
-		help_map_count_title = "You can get <b>Transformice</b> titles by completing parkour maps!",
-		help_checkpoint_count_title = "You can get <b>Transformice</b> titles by collecting all checkpoints in parkour maps!",
-		help_badge_1 = "This player has been a parkour staff member in the past.",
-		help_badge_2 = "This player is or was in the page 1 of the overall leaderboard.",
-		help_badge_3 = "This player is or was in the page 2 of the overall leaderboard.",
-		help_badge_4 = "This player is or was in the page 3 of the overall leaderboard.",
-		help_badge_5 = "This player is or was in the page 4 of the overall leaderboard.",
-		help_badge_6 = "This player is or was in the page 5 of the overall leaderboard.",
-		help_badge_7 = "This player has been in the podium of the weekly leaderboard when it has reset.",
-		help_badge_8 = "This player has got a record of 30 maps per hour.",
-		help_badge_9 = "This player has got a record of 35 maps per hour.",
-		help_badge_10 = "This player has got a record of 40 maps per hour.",
-		help_badge_11 = "This player has got a record of 45 maps per hour.",
-		help_badge_12 = "This player has got a record of 50 maps per hour.",
-		help_badge_13 = "This player has got a record of 55 maps per hour.",
-		help_badge_14 = "This player has verified their discord account in the official parkour server (type <b>!discord</b>).",
-		help_badge_15 = "This player has got the fastest time in 1 map.",
-		help_badge_16 = "This player has got the fastest time in 5 maps.",
-		help_badge_17 = "This player has got the fastest time in 10 maps.",
-		help_badge_18 = "This player has got the fastest time in 15 maps.",
-		help_badge_19 = "This player has got the fastest time in 20 maps.",
-		help_badge_20 = "This player has got the fastest time in 25 maps.",
-		help_badge_21 = "This player has got the fastest time in 30 maps.",
-		help_badge_22 = "This player has got the fastest time in 35 maps.",
-		help_badge_23 = "This player has got the fastest time in 40 maps.",
-		make_public = "make public",
-		make_private = "make private",
-		moderators = "Moderators",
+					"Position dans le classement global: <b><v>%s</v></b>\n\n" ..
+					"Position dans le classement hebdomadaire: <b><v>%s</v></b>\n\n%s"),
+		map_count = "Nombre de maps complétées: <b><v>%s</v> / <a href='event:_help:yellow_maps'><j>%s</j></a> / <a href='event:_help:red_maps'><r>%s</r></a></b>",
+		title_count = ("<b><j>«!»</j></b> Maps terminées : <b><a href='event:_help:map_count_title'><v>%s</v></a></b>\n\n" ..
+					"<b><j>«!»</j></b> Checkpoints atteints : <b><a href='event:_help:checkpoint_count_title'><v>%s</v></a></b>"),
+		help_badge = "Les badges sont des accomplissements que peuvent obtenir les joueurs. Clique sur un badge pour voir sa description.",
+		help_private_maps = "Ce joueur ne souhaite pas partager son nombre de maps complétées ! Tu peux également le cacher sur ton profil.",
+		help_yellow_maps = "Les cartes en jaune sont les cartes complétées cette semaine.",
+		help_red_maps = "Les cartes en rouge ont été complétées cette heure-ci.",
+		help_map_count_title = "Tu peux recevoir des titres de <b>Transformice</b> en complétant des maps parkour !",
+		help_checkpoint_count_title = "Tu peux recevoir des titres de <b>Transformice</b> en atteignant tous les checkpoints dans les maps parkour !",
+		help_badge_1 = "Ce joueur a été un membre du staff de parkour.",
+		help_badge_2 = "Ce joueur est ou était sur la page 1 du classement global.",
+		help_badge_3 = "Ce joueur est ou était sur la page 2 du classement global.",
+		help_badge_4 = "Ce joueur est ou était sur la page 3 du classement global.",
+		help_badge_5 = "Ce joueur est ou était sur la page 4 du classement global.",
+		help_badge_6 = "Ce joueur est ou était sur la page 5 du classement global.",
+		help_badge_7 = "Ce joueur a été sur le podium à la fin d'un classement hebdomadaire.",
+		help_badge_8 = "Ce joueur a un record de 30 cartes par heure.",
+		help_badge_9 = "Ce joueur a un record de 35 cartes par heure.",
+		help_badge_10 = "Ce joueur a un record de 40 cartes par heure.",
+		help_badge_11 = "Ce joueur a un record de 45 cartes par heure.",
+		help_badge_12 = "Ce joueur a un record de 50 cartes par heure.",
+		help_badge_13 = "Ce joueur a un record de 55 cartes par heure.",
+		help_badge_14 = "Ce joueur a vérifié son compte discord sur le discord officiel de parkour (écris <b>!discord</b>).",
+		help_badge_15 = "Ce joueur a obtenu le temps le plus rapide sur 1 carte.",
+		help_badge_16 = "Ce joueur a obtenu le temps le plus rapide sur 5 cartes.",
+		help_badge_17 = "Ce joueur a obtenu le temps le plus rapide sur 10 cartes.",
+		help_badge_18 = "Ce joueur a obtenu le temps le plus rapide sur 15 cartes.",
+		help_badge_19 = "Ce joueur a obtenu le temps le plus rapide sur 20 cartes.",
+		help_badge_20 = "Ce joueur a obtenu le temps le plus rapide sur 25 cartes.",
+		help_badge_21 = "Ce joueur a obtenu le temps le plus rapide sur 30 cartes.",
+		help_badge_22 = "Ce joueur a obtenu le temps le plus rapide sur 35 cartes.",
+		help_badge_23 = "Ce joueur a obtenu le temps le plus rapide sur 40 cartes.",
+		make_public = "Rendre publique",
+		make_private = "Rendre privé",
+		moderators = "Modérateurs",
 		mappers = "Mappers",
-		managers = "Managers",
-		administrators = "Administrators",
-		close = "Close",
-		cant_load_bot_profile = "<v>[#] <r>You can't see this bot's profile since #parkour uses it internally to work properly.",
-		cant_load_profile = "<v>[#] <r>The player <b>%s</b> seems to be offline or does not exist.",
-		like_map = "Do you like this map?",
-		yes = "Yes",
-		no = "No",
-		idk = "I don't know",
-		unknown = "Unknown",
-		powers = "Powers",
-		press = "<vp>Press %s",
-		click = "<vp>Left click",
-		ranking_pos = "Rank #%s",
-		completed_maps = "<p align='center'><BV><B>Completed maps: %s</B></p></BV>",
-		leaderboard = "Leaderboard",
+		managers = "Manageurs",
+		administrators = "Administrateurs",
+		close = "Fermer",
+		cant_load_bot_profile = "<v>[#] <r>Tu ne peux pas voir le profile de ce robot car #parkour l'utilise intérieurement pour faire fonctionner le module correctement.",
+		cant_load_profile = "<v>[#] <r>Le joueur <b>%s</b> semble être hors ligne ou n'existe pas.",
+		like_map = "Aimez-vous cette carte?",
+		yes = "Oui",
+		no = "Non",
+		idk = "Je ne sais pas",
+		unknown = "Inconnu",
+		powers = "Pouvoirs",
+		press = "<vp>Appuyer sur %s",
+		click = "<vp>Clique gauche",
+		ranking_pos = "Classement #%s",
+		completed_maps = "<p align='center'><BV><B>Cartes complétées: %s</B></p></BV>",
+		leaderboard = "Classement",
 		position = "<V><p align=\"center\">Position",
-		username = "<V><p align=\"center\">Username",
-		community = "<V><p align=\"center\">Community",
-		completed = "<V><p align=\"center\">Completed maps",
-		overall_lb = "Overall",
-		weekly_lb = "Weekly",
-		new_lang = "<v>[#] <d>Language set to English",
+		username = "<V><p align=\"center\">Pseudo",
+		community = "<V><p align=\"center\">Communauté",
+		completed = "<V><p align=\"center\">Cartes complétées",
+		overall_lb = "Permanent",
+		weekly_lb = "Hebdomadaire",
+		new_lang = "<v>[#] <d>Langue changée vers Français",
 
 		-- Power names
-		balloon = "Balloon",
-		masterBalloon = "Master Ballon",
-		bubble = "Bubble",
-		fly = "Fly",
-		snowball = "Snowball",
-		speed = "Speed",
-		teleport = "Teleport",
-		smallbox = "Small box",
-		cloud = "Cloud",
-		rip = "Tombstone",
-		choco = "Chocoplank",
-		bigBox = "Big box",
+		balloon = "Ballon",
+		masterBalloon = "Ballon Maître",
+		bubble = "Bulle",
+		fly = "Voler",
+		snowball = "Boule de neige",
+		speed = "Accélération",
+		teleport = "Téléportation",
+		smallbox = "Petite boîte",
+		cloud = "Nuage",
+		rip = "Tombe",
+		choco = "Planche de chocolat",
+		bigBox = "Grande boîte",
 		trampoline = "Trampoline",
-		toilet = "Toilet",
-		pig = "Piglet",
-		sink = "Sink",
-		bathtub = "Bathtub",
-		campfire = "Campfire",
-		chair = "Chair",
+		toilet = "Toilettes",
+		pig = "Cochon",
+		sink = "Evier",
+		bathtub = "Baignoire",
+		campfire = "Feu de Camp",
+		chair = "Chaise",
 	}
-	--[[ End of file translations/parkour/en.lua ]]--
-	--[[ File translations/parkour/es.lua ]]--
-	translations.es = {
-		name = "es",
-		fullname = "Español",
-
-		-- Error messages
-		corrupt_map = "<r>Mapa corrupto. Cargando otro.",
-		corrupt_map_vanilla = "<r>[ERROR] <n>No se pudo obtener información de este mapa.",
-		corrupt_map_mouse_start = "<r>[ERROR] <n>El mapa tiene que tener un punto de inicio de los ratones.",
-		corrupt_map_needing_chair = "<r>[ERROR] <n>El mapa tiene que tener el sillón del final.",
-		corrupt_map_missing_checkpoints = "<r>[ERROR] <n>El mapa tiene que tener al menos un checkpoint (anclaje amarillo).",
-		corrupt_data = "<r>Tristemente, tus datos estaban corruptos. Se han reiniciado.",
-		min_players = "<r>Para guardar datos, deben haber al menos 4 jugadores únicos en la sala. <bl>[%s/%s]",
-		tribe_house = "<r>Para guardar datos, debes jugar fuera de una casa de tribu.",
-		invalid_syntax = "<r>Sintaxis inválida.",
-		code_error = "<r>Apareció un error: <bl>%s-%s-%s %s",
-		emergency_mode = "<r>Empezando apagado de emergencia, no se admiten más jugadores. Por favor ve a otra sala #parkour.",
-		leaderboard_not_loaded = "<r>La tabla de clasificación aun no ha sido cargada. Espera un minuto.",
-		max_power_keys = "<v>[#] <r>Solo puedes tener como máximo %s poderes en la misma tecla.",
-
-		-- Help window
-		help = "Ayuda",
-		staff = "Staff",
-		rules = "Reglas",
-		contribute = "Contribuir",
-		changelog = "Novedades",
-		help_help = "<p align = 'center'><font size = '14'>¡Bienvenido a <T>#parkour!</T></font></p>\n<font size = '12'><p align='center'><J>Tu objetivo es alcanzar todos los checkpoints hasta que completes el mapa.</J></p>\n\n<N>• Presiona la tecla <O>O</O>, escribe <O>!op</O> o clickea el <O>botón de configuración</O> para abrir el <T>menú de opciones</T>.\n• Presiona la tecla <O>P</O> o clickea el <O>ícono de la mano</O> arriba a la derecha para abrir el <T>menú de poderes</T>.\n• Presiona la tecla <O>L</O> o escribe <O>!lb</O> para abrir el <T>ranking</T>.\n• Presiona la tecla <O>M</O> o <O>Delete</O> como atajo para <T>/mort</T>, podes alternarlas en el menú de <J>Opciones</J>.\n• Para conocer más acerca de nuestro <O>staff</O> y las <O>reglas de parkour</O>, clickea en las pestañas de <T>Staff</T> y <T>Reglas</T>.\n• Click <a href='event:discord'><o>here</o></a> to get the discord invite link and <a href='event:map_submission'><o>here</o></a> to get the map submission topic link.\n• Use <o>up</o> and <o>down</o> arrow keys when you need to scroll.\n\n<p align = 'center'><font size = '13'><T>¡Las contribuciones están abiertas! Para más detalles, ¡clickea en la pestaña <O>Contribuir</O>!</T></font></p>",
-		help_staff = "<p align = 'center'><font size = '13'><r>NOTA: El staff de Parkour NO ES staff de Transformice y NO TIENEN ningún poder en el juego, sólamente dentro del módulo.</r>\nEl staff de Parkour se asegura de que el módulo corra bien con la menor cantidad de problemas, y siempre están disponibles para ayudar a los jugadores cuando sea necesario.</font></p>\nPuedes escribir <D>!staff</D> en el chat para ver la lista de staff.\n\n<font color = '#E7342A'>Administradores:</font> Son los responsables de mantener el módulo añadiendo nuevas actualizaciones y arreglando bugs.\n\n<font color = '#D0A9F0'>Lideres de Equipos:</font> Ellos supervisan los equipos de Moderadores y Mappers, asegurándose de que hagan un buen trabajo. También son los responsables de reclutar nuevos miembros al staff.\n\n<font color = '#FFAAAA'>Moderadores:</font> Son los responsables de ejercer las reglas del módulo y sancionar a quienes no las sigan.\n\n<font color = '#25C059'>Mappers:</font> Son los responsables de revisar, añadir y quitar mapas en el módulo para asegurarse de que tengas un buen gameplay.",
-		help_rules = "<font size = '13'><B><J>Todas las reglas en los Terminos y Condiciones de Transformice también aplican a #parkour</J></B></font>\n\nSi encuentras algún jugador rompiendo estas reglas, susurra a los moderadores de parkour en el juego. Si no hay moderadores online, es recomendable reportarlo en discord.\nCuando reportes, por favor agrega el servidor, el nombre de la sala, y el nombre del jugador.\n• Ej: en-#parkour10 Blank#3495 trollear\nEvidencia, como fotos, videos y gifs ayudan y son apreciados, pero no son necesarios.\n\n<font size = '11'>• No se permite el uso de <font color = '#ef1111'>hacks, glitches o bugs</font>\n• <font color = '#ef1111'>Farmear con VPN</font> será considerado un <B>abuso</B> y no está permitido. <p align = 'center'><font color = '#cc2222' size = '12'><B>\nCualquier persona rompiendo estas reglas será automáticamente baneado.</B></font></p>\n\n<font size = '12'>Transformice acepta el concepto de trollear. Pero <font color='#cc2222'><B>no está permitido en #parkour.</B></font></font>\n\n<p align = 'center'><J>Trollear es cuando un jugador intencionalmente usa sus poderes o consumibles para hacer que otros jugadores no completen el mapa.</j></p>\n• Trollear como venganza <B>no es una razón válida</B> para trollear a alguien y aún así seras sancionado.\n• Ayudar a jugadores que no quieren completar el mapa con ayuda y no parar cuando te lo piden también es considerado trollear.\n• <J>Si un jugador no quiere ayuda, por favor ayuda a otros jugadores</J>. Sin embargo, si otro jugador necesita ayuda en el mismo punto, puedes ayudarlos [a los dos].\n\nSi un jugador es atrapado trolleando, será sancionado en base de tiempo. Trollear repetidas veces llevará a sanciones más largas y severas.",
-		help_contribute = "<font size='14'>\n<p align='center'>El equipo de administración de parkour ama el codigo abierto porque <t>ayuda a la comunidad</t>. Podés <o>ver</o> y <o>modificar</o> el código de parkour en <o><u><a href='event:github'>GitHub</a></u></o>.\n\nMantener el módulo es <t>estrictamente voluntario</t>, por lo que cualquier ayuda con respecto al <t>código</t>, <t>reportes de bugs</t>, <t>sugerencias</t> y <t>creación de mapas</t> siempre será <u>bienvenida y apreciada</u>.\nPodés <vp>reportar bugs</vp> y <vp>dar sugerencias</vp> en <o><u><a href='event:discord'>Discord</a></u></o> y/o <o><u><a href='event:github'>GitHub</a></u></o>.\nPodés <vp>enviar tus mapas</vp> en nuestro <o><u><a href='event:map_submission'>Hilo del Foro</a></u></o>.\n\nMantener parkour no es caro, pero tampoco es gratis. Realmente apreciaríamos si pudieras ayudarnos <t>donando cualquier cantidad</t> <o><u><a href='event:donate'>aquí</a></u></o>.\n<u>Todas las donaciones serán destinadas a mejorar el módulo.</u></p>",
-		help_changelog = "<font size='13'><p align='center'><o>Version 2.10.0 - 17/04/2021</o></p>\n\n<font size='11'>• <font size='13'>¡<b><j>TRES</J></b> nuevos títulos fueron añadidos a Transformice que solamente pueden ser desbloqueados al jugar <font color='#1A7EC9'><b>#parkour</b></font>!</font>\n• Dos nuevas estadísticas fueron añadidas al perfil.\n• Ajustes menores en los textos.",
-
-		-- Congratulation messages
-		reached_level = "<d>¡Felicitaciones! Alcanzaste el nivel <vp>%s</vp>. (<t>%ss</t>)",
-		finished = "<d><o>%s</o> completó el parkour en <vp>%s</vp> segundos, <fc>¡felicitaciones!",
-		unlocked_power = "<ce><d>%s</d> desbloqueó el poder <vp>%s<ce>.",
-
-		-- Information messages
-		mod_apps = "<j>¡Las aplicaciones para moderador de parkour están abiertas! Usa este link: <rose>%s",
-		staff_power = "<r>El staff de Parkour <b>no tiene</b> ningún poder afuera de las salas de #parkour.",
-		donate = "<vp>¡Escribe <b>!donate</b> si te gustaría donar a este módulo!",
-		paused_events = "<cep><b>[¡Advertencia!]</b> <n>El módulo está entrando en estado crítico y está siendo pausado.",
-		resumed_events = "<n2>El módulo ha sido reanudado.",
-		welcome = "<n>¡Bienvenido a <t>#parkour</t>!",
-		module_update = "<r><b>[¡Advertencia!]</b> <n>El módulo se actualizará en <d>%02d:%02d</d>.",
-		leaderboard_loaded = "<j>La tabla de clasificación ha sido cargada. Presiona L para abrirla.",
-		kill_minutes = "<R>Tus poderes fueron desactivados por %s minutos.",
-		permbanned = "<r>Has sido baneado permanentemente de #parkour.",
-		tempbanned = "<r>Has sido baneado de #parkour por %s minutos.",
-		forum_topic = "<rose>Para más información del módulo visita este link: %s",
-		report = "<j>¿Quieres reportar a un jugador de parkour? <t><b>/c Parkour#8558 .report Usuario#0000</b></t>",
-
-		-- Easter Eggs
-		easter_egg_0  = "<ch>La cuenta atrás empezó...",
-		easter_egg_1  = "<ch>¡Faltan menos de 24 horas!",
-		easter_egg_2  = "<ch>¡Wow, viniste temprano! ¿Estás emocionado?",
-		easter_egg_3  = "<ch>Una sorpresa nos espera...",
-		easter_egg_4  = "<ch>¿Ya sabes lo que está a punto de pasar...?",
-		easter_egg_5  = "<ch>El reloj sigue contando...",
-		easter_egg_6  = "<ch>¡La sorpresa se acerca!",
-		easter_egg_7  = "<ch>La fiesta está por comenzar...",
-		easter_egg_8  = "<ch>Mira tu reloj, ¿ya es hora?",
-		easter_egg_9  = "<ch>Ten cuidado, el tiempo pasa rápido...",
-		easter_egg_10 = "<ch>Siéntate y relájate, ¡ya será mañana en poco tiempo!",
-		easter_egg_11 = "<ch>Iré a dormir temprano, ¡el tiempo pasará más rápido!",
-		easter_egg_12 = "<ch>La paciencia es una virtud",
-		easter_egg_13 = "<ch>https://youtu.be/9jK-NcRmVcw",
-		double_maps = "<bv>Los mapas cuentan doble el sábado (GMT+2) y todos los poderes están activados por la semana del cumpleaños de parkour!",
-		double_maps_start = "<rose>¡ES EL CUMPLEAÑOS DE PARKOUR! Los mapas cuentan doble y todos los poderes están disponibles. ¡Muchas gracias por jugar con nosotros!",
-		double_maps_end = "<rose>El cumpleaños de parkour acaba de terminar. ¡Muchas gracias por jugar con nosotros!",
-
-		-- Records
-		records_enabled = "<v>[#] <d>El modo de récords está activado en esta sala. ¡Las estadísticas no cuentan y los poderes están desactivados!\nPuedes encontrar más información sobre récords en <b>%s</b>",
-		records_admin = "<v>[#] <d>Eres un administrador de esta sala de récords. Puedes usar los comandos <b>!map</b>, <b>!setcp</b>, <b>!pw</b> y <b>!time</b>.",
-		records_completed = "<v>[#] <d>¡Completaste el mapa! Si te gustaría rehacerlo, escribe <b>!redo</b>.",
-		records_submit = "<v>[#] <d>¡Wow! Parece que completaste el mapa con el tiempo más rápido en la sala. Si te gustaría enviar tu record, escribe <b>!submit</b>.",
-		records_invalid_map = "<v>[#] <r>Parece que este mapa no está en la rotación de parkour... ¡No puedes enviar un récord en el!",
-		records_not_fastest = "<v>[#] <r>Parece que no eres el más rápido en la sala...",
-		records_already_submitted = "<v>[#] <r>¡Ya enviaste un récord para este mapa!",
-		records_submitted = "<v>[#] <d>Tu récord para el mapa <b>%s</b> ha sido enviado.",
-
-		-- Miscellaneous
-		afk_popup = "\n<p align='center'><font size='30'><bv><b>ESTÁS EN MODO AFK</b></bv>\nMUÉVETE PARA REAPARECER</font>\n\n<font size='30'><u><t>Recordatorios:</t></u></font>\n\n<font size='15'><r>¡Los jugadores con una línea roja sobre ellos no quieren ayuda!\n¡Trollear/bloquear a otros jugadores en parkour NO está permitido!<d>\n¡Únete a nuestro <cep><a href='event:discord'>servidor de discord</a></cep>!\n¿Quieres contribuir con código? Vé a nuestro <cep><a href='event:github'>repositorio de github</a></cep>\n¿Tienes un buen mapa para enviar? Envíalo a nuestro <cep><a href='event:map_submission'>hilo de presentaciones de mapas</a></cep>\n¡Checkea nuestro <cep><a href='event:forum'>hilo oficial</a></cep> para más información!\n¡Ayúdanos <cep><a href='event:donate'>donando!</a></cep>",
-		options = "<p align='center'><font size='20'>Opciones de Parkour</font></p>\n\nUsar teclado <b>QWERTY</b> (desactivar si usas <b>AZERTY</b>)\n\nUsar la tecla <b>M</b> como atajo para <b>/mort</b> (desactivar si usas <b>DEL</b>)\n\nMostrar tiempos de espera de tus poderes\n\nMostrar el botón de poderes\n\nMostrar el botón de ayuda\n\nMostrar mensajes al completar un mapa\n\nMostrar indicador para no recibir ayuda",
-		cooldown = "<v>[#] <r>Espera unos segundos antes de hacer eso de nuevo.",
-		power_options = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'>Teclado <b>QWERTY</b>" ..
-						 "\n\n<b>Esconder</b> cantidad de mapas" ..
-						 "\n\nUsar <b>tecla original</b>"),
-		unlock_power = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Completa <v>%s</v> mapas" ..
-						"<font size='5'>\n\n</font>para desbloquear" ..
-						"<font size='5'>\n\n</font><v>%s</v>"),
-		upgrade_power = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Completa <v>%s</v> mapas" ..
-						"<font size='5'>\n\n</font>para mejorar a" ..
-						"<font size='5'>\n\n</font><v>%s</v>"),
-		unlock_power_rank = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Posición <v>%s</v>" ..
-						"<font size='5'>\n\n</font>para desbloquear" ..
-						"<font size='5'>\n\n</font><v>%s</v>"),
-		upgrade_power_rank = ("<font size='13' face='Lucida Console,Liberation Mono,Courier New'><p align='center'>Posición <v>%s</v>" ..
-						"<font size='5'>\n\n</font>para mejorar a" ..
-						"<font size='5'>\n\n</font><v>%s</v>"),
-		maps_info = ("<p align='center'><font size='13' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
-					 "<font size='5'>\n\n</font>Mapas Completados"),
-		overall_info = ("<p align='center'><font size='13' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
-						"<font size='5'>\n\n</font>Posición General"),
-		weekly_info = ("<p align='center'><font size='13' face='Lucida Console,Liberation Mono,Courier New'><b><v>%s</v></b>" ..
-					   "<font size='5'>\n\n</font>Posición Semanal"),
-		badges = "<font size='14' face='Lucida Console,Liberation Mono,Courier New,Verdana'>Insignias (%s): <a href='event:_help:badge'><j>[?]</j></a>",
-		private_maps = "<bl>La cantidad de mapas de este jugador es privada. <a href='event:_help:private_maps'><j>[?]</j></a></bl>\n",
-		profile = ("<font size='12' face='Lucida Console,Liberation Mono,Courier New,Verdana'>%s%s %s\n\n" ..
-					"Posición general: <b><v>%s</v></b>\n\n" ..
-					"Posición semanal: <b><v>%s</v></b>\n\n%s"),
-		map_count = "Cantidad de mapas: <b><v>%s</v> / <a href='event:_help:yellow_maps'><j>%s</j></a> / <a href='event:_help:red_maps'><r>%s</r></a></b>",
-		title_count = ("<b><j>«!»</j></b> Mapas completados: <b><a href='event:_help:map_count_title'><v>%s</v></a></b>\n\n" ..
-					"<b><j>«!»</j></b> Checkpoints obttenidos: <b><a href='event:_help:checkpoint_count_title'><v>%s</v></a></b>"),
-		help_badge = "Las insignias son logros que un usuario puede obtener. Clickéalas para ver su descripción.",
-		help_private_maps = "¡A este jugador no le gusta compartir su cantidad de mapas! Podés esconder la tuya en tu perfil.",
-		help_yellow_maps = "Los mapas en amarillo fueron completados en esta semana.",
-		help_red_maps = "Los mapas en rojo fueron completados en la última hora.",
-		help_map_count_title = "¡Puedes obtener títulos al completar mapas de parkour!",
-		help_checkpoint_count_title = "¡Puedes obtener títulos al agarrar todos los checkpoints jugando parkour!",
-		help_badge_1 = "Este jugador fue un miembro del staff de parkour.",
-		help_badge_2 = "Este jugador está o estuvo en la página 1 del ranking general.",
-		help_badge_3 = "Este jugador está o estuvo en la página 2 del ranking general.",
-		help_badge_4 = "Este jugador está o estuvo en la página 3 del ranking general.",
-		help_badge_5 = "Este jugador está o estuvo en la página 4 del ranking general.",
-		help_badge_6 = "Este jugador está o estuvo en la página 5 del ranking general.",
-		help_badge_7 = "Este jugador estuvo en el podio cuando el ranking semanal se reinició.",
-		help_badge_8 = "Este jugador tiene un record de 30 mapas en una hora.",
-		help_badge_9 = "Este jugador tiene un record de 35 mapas en una hora.",
-		help_badge_10 = "Este jugador tiene un record de 40 mapas en una hora.",
-		help_badge_11 = "Este jugador tiene un record de 45 mapas en una hora.",
-		help_badge_12 = "Este jugador tiene un record de 50 mapas en una hora.",
-		help_badge_13 = "Este jugador tiene un record de 55 mapas en una hora.",
-		help_badge_14 = "Este jugador verificó su cuenta de discord en el servidor oficial de parkour (escribe <b>!discord</b>).",
-		help_badge_15 = "Este jugador tuvo el tiempo más rápido en 1 mapa.",
-		help_badge_16 = "Este jugador tuvo el tiempo más rápido en 5 mapas.",
-		help_badge_17 = "Este jugador tuvo el tiempo más rápido en 10 mapas.",
-		help_badge_18 = "Este jugador tuvo el tiempo más rápido en 15 mapas.",
-		help_badge_19 = "Este jugador tuvo el tiempo más rápido en 20 mapas.",
-		help_badge_20 = "Este jugador tuvo el tiempo más rápido en 25 mapas.",
-		help_badge_21 = "Este jugador tuvo el tiempo más rápido en 30 mapas.",
-		help_badge_22 = "Este jugador tuvo el tiempo más rápido en 35 mapas.",
-		help_badge_23 = "Este jugador tuvo el tiempo más rápido en 40 mapas.",
-		make_public = "hacer público",
-		make_private = "hacer privado",
-		moderators = "Moderadores",
-		mappers = "Mappers",
-		managers = "Líderes",
-		administrators = "Administradores",
-		close = "Cerrar",
-		cant_load_bot_profile = "<v>[#] <r>No puedes ver el perfil de este bot ya que #parkour lo usa internamente para funcionar.",
-		cant_load_profile = "<v>[#] <r>El jugador <b>%s</b> parece estar desconectado o no existe.",
-		like_map = "¿Te gusta este mapa?",
-		yes = "Sí",
-		no = "No",
-		idk = "No lo sé",
-		unknown = "Desconocido",
-		powers = "Poderes",
-		press = "<vp>Presiona %s",
-		click = "<vp>Haz clic",
-		ranking_pos = "Rank #%s",
-		completed_maps = "<p align='center'><BV><B>Mapas completados: %s</B></p></BV>",
-		leaderboard = "Tabla de clasificación",
-		position = "<V><p align=\"center\">Posición",
-		username = "<V><p align=\"center\">Jugador",
-		community = "<V><p align=\"center\">Comunidad",
-		completed = "<V><p align=\"center\">Mapas completados",
-		overall_lb = "General",
-		weekly_lb = "Semanal",
-		new_lang = "<v>[#] <d>Lenguaje cambiado a Español",
-
-		-- Power names
-		balloon = "Globo",
-		masterBalloon = "Globo Maestro",
-		bubble = "Burbuja",
-		fly = "Volar",
-		snowball = "Bola de nieve",
-		speed = "Velocidad",
-		teleport = "Teletransporte",
-		smallbox = "Caja pequeña",
-		cloud = "Nube",
-		rip = "Tumba",
-		choco = "Chocolate",
-		bigBox = "Caja grande",
-		trampoline = "Trampolín",
-		toilet = "Inodoro",
-		pig = "Cerdito",
-		sink = "Lavamanos",
-		bathtub = "Bañera",
-		campfire = "Fogata",
-		chair = "Silla",
-	}
-	--[[ End of file translations/parkour/es.lua ]]--
+	--[[ End of file translations/parkour/fr.lua ]]--
 	--[[ End of directory translations/parkour ]]--
 	--[[ File modes/parkour/timers.lua ]]--
 	local timers = {}
@@ -4436,6 +4436,7 @@ local function initialize_parkour() -- so it uses less space after building
 			if players_level[player] == 1 and not times.generated[player] then
 				times.generated[player] = now
 				times.checkpoint[player] = now
+				tfm.exec.freezePlayer(player, false)
 			end
 			times.movement[player] = now
 
@@ -4529,6 +4530,12 @@ local function initialize_parkour() -- so it uses less space after building
 		if bans[room.playerList[player].id] then return tfm.exec.killPlayer(player) end
 		if (not levels) or (not players_level[player]) then return end
 
+		if (players_level[player] == 1
+			and not times.generated[player]
+			and records_admins) then
+			tfm.exec.freezePlayer(player, true)
+		end
+
 		local level = levels[ players_level[player] ]
 		if not level then return end
 		tfm.exec.movePlayer(player, level.x, level.y)
@@ -4572,6 +4579,12 @@ local function initialize_parkour() -- so it uses less space after building
 				players_level[player] = 1
 				changePlayerSize(player, size)
 				tfm.exec.setPlayerScore(player, 1, false)
+			end
+
+			if records_admins then
+				for player in next, in_room do
+					tfm.exec.freezePlayer(player, true)
+				end
 			end
 		end
 
@@ -6845,7 +6858,7 @@ local function initialize_parkour() -- so it uses less space after building
 			return
 
 		elseif cmd == "submit" then
-			--[[if not records_admins then return end
+			if not records_admins then return end
 			local map = tonumber(string.sub(room.currentMap, 2))
 
 			if fastest.player ~= player then
@@ -6889,10 +6902,7 @@ local function initialize_parkour() -- so it uses less space after building
 				 room.shortName .. "\000" ..
 				 checkpoint_info.version)
 			)
-			tfm.exec.chatMessage("<v>[#] <d>Your record will be submitted shortly.", player)]]
-
-			tfm.exec.chatMessage("<v>[#] <d>Sorry, record submissions will be disabled until further notice.", player)
-			return
+			tfm.exec.chatMessage("<v>[#] <d>Your record will be submitted shortly.", player)
 
 		elseif cmd == "pause" then -- logged
 			if not ranks.admin[player] then return end
@@ -7571,41 +7581,6 @@ local function initialize_parkour() -- so it uses less space after building
 		end)
 	end
 	--[[ End of file modes/parkour/objects/Interface.lua ]]--
-	--[[ File modes/parkour/objects/WindowBackground.lua ]]--
-	local WindowBackground = function(self)
-		self:addTextArea({
-			color = {0x78462b, 0x78462b, 1}
-		}):addTextArea({
-			y = self.height / 4,
-			height = self.height / 2,
-			color = {0x9d7043, 0x9d7043, 1}
-		}):addTextArea({
-			x = self.width / 4,
-			width = self.width / 2,
-			color = {0x9d7043, 0x9d7043, 1}
-		}):addTextArea({
-			width = 20, height = 20,
-			color = {0xbeb17d, 0xbeb17d, 1}
-		}):addTextArea({
-			x = self.width - 20,
-			width = 20, height = 20,
-			color = {0xbeb17d, 0xbeb17d, 1}
-		}):addTextArea({
-			y = self.height - 20,
-			width = 20, height = 20,
-			color = {0xbeb17d, 0xbeb17d, 1}
-		}):addTextArea({
-			x = self.width - 20,
-			y = self.height - 20,
-			width = 20, height = 20,
-			color = {0xbeb17d, 0xbeb17d, 1}
-		}):addTextArea({
-			x = 3, y = 3,
-			width = self.width - 6, height = self.height - 6,
-			color = {0x1c3a3e, 0x232a35, 1}
-		})
-	end
-	--[[ End of file modes/parkour/objects/WindowBackground.lua ]]--
 	--[[ File modes/parkour/objects/Button.lua ]]--
 	local Button
 	do
@@ -7761,6 +7736,41 @@ local function initialize_parkour() -- so it uses less space after building
 		end)
 	end
 	--[[ End of file modes/parkour/objects/Button.lua ]]--
+	--[[ File modes/parkour/objects/WindowBackground.lua ]]--
+	local WindowBackground = function(self)
+		self:addTextArea({
+			color = {0x78462b, 0x78462b, 1}
+		}):addTextArea({
+			y = self.height / 4,
+			height = self.height / 2,
+			color = {0x9d7043, 0x9d7043, 1}
+		}):addTextArea({
+			x = self.width / 4,
+			width = self.width / 2,
+			color = {0x9d7043, 0x9d7043, 1}
+		}):addTextArea({
+			width = 20, height = 20,
+			color = {0xbeb17d, 0xbeb17d, 1}
+		}):addTextArea({
+			x = self.width - 20,
+			width = 20, height = 20,
+			color = {0xbeb17d, 0xbeb17d, 1}
+		}):addTextArea({
+			y = self.height - 20,
+			width = 20, height = 20,
+			color = {0xbeb17d, 0xbeb17d, 1}
+		}):addTextArea({
+			x = self.width - 20,
+			y = self.height - 20,
+			width = 20, height = 20,
+			color = {0xbeb17d, 0xbeb17d, 1}
+		}):addTextArea({
+			x = 3, y = 3,
+			width = self.width - 6, height = self.height - 6,
+			color = {0x1c3a3e, 0x232a35, 1}
+		})
+	end
+	--[[ End of file modes/parkour/objects/WindowBackground.lua ]]--
 	--[[ File modes/parkour/objects/Toggle.lua ]]--
 	local Toggle
 	do
@@ -8337,6 +8347,60 @@ local function initialize_parkour() -- so it uses less space after building
 	--[[ End of file modes/parkour/interfaces/requirements/keyboard.lua ]]--
 	--[[ End of directory modes/parkour/interfaces/requirements ]]--
 	--[[ Directory modes/parkour/interfaces ]]--
+	--[[ File modes/parkour/interfaces/tracker.lua ]]--
+	local PowerTracker
+	do
+		local nameCache = {}
+		local function formatName(name)
+			if nameCache[name] then
+				return nameCache[name]
+			end
+
+			nameCache[name] = string.gsub(
+				string.gsub(name, "(#%d%d%d%d)", "<font size='10'><g>%1</g></font>"),
+				"([Hh]t)tp", "%1<->tp"
+			)
+			return nameCache[name]
+		end
+
+		PowerTracker = Interface.new(200, 50, 400, 300, true)
+			:loadTemplate(WindowBackground)
+
+			:addTextArea({
+				alpha = 0,
+				text = "<p align='center'><font size='14'><cep><b>Power Tracker</b></cep></font></p>"
+			})
+
+			:addTextArea({
+				canUpdate = true,
+				y = 25, height = 240,
+				alpha = 0,
+
+				text = function(self, player, powers)
+					local pieces, count = {}, 0
+
+					local power
+					for index = powers._count, math.max(powers._count - 18, 1), -1 do
+						power = powers[index]
+						count = count + 1
+						pieces[count] = formatName(power[1]) .. "<n> -> </n>" .. power[2]
+					end
+
+					return "<v>" .. table.concat(pieces, "\n")
+				end
+			})
+
+			:loadComponent(
+				Button.new():setTranslation("close")
+
+				:onClick(function(self, player)
+					self.parent:remove(player)
+				end)
+
+				:setPosition(10, 275):setSize(380, 15)
+			)
+	end
+	--[[ End of file modes/parkour/interfaces/tracker.lua ]]--
 	--[[ File modes/parkour/interfaces/help.lua ]]--
 	local HelpInterface
 	do
@@ -8669,232 +8733,6 @@ local function initialize_parkour() -- so it uses less space after building
 		end)
 	end
 	--[[ End of file modes/parkour/interfaces/help.lua ]]--
-	--[[ File modes/parkour/interfaces/newbadge.lua ]]--
-	do
-		NewBadgeInterface = Interface.new(340, 130, 120, 140, true)
-			:loadTemplate(WindowBackground)
-
-			:setShowCheck(function(self, player, group, badge)
-				if self.open[player] then
-					self:update(player, group, badge)
-					return false
-				end
-				return true
-			end)
-
-			:addImage({
-				image = function(self, player, group, badge)
-					return badges[group][badge][3]
-				end,
-				target = "&1",
-				x = 10, y = 5
-			})
-
-			:loadComponent(
-				Button.new():setTranslation("close")
-
-				:onClick(function(self, player)
-					self.parent:remove(player)
-				end)
-
-				:setSize(100, 15):setPosition(10, 115)
-			)
-	end
-	--[[ End of file modes/parkour/interfaces/newbadge.lua ]]--
-	--[[ File modes/parkour/interfaces/profile.lua ]]--
-	local Profile
-	do
-		local nameCache = {}
-		local function formatName(name)
-			if nameCache[name] then
-				return nameCache[name]
-			end
-
-			nameCache[name] = string.gsub(
-				string.gsub(name, "(#%d%d%d%d)", "<font size='15'><g>%1</g></font>"),
-				"([Hh]t)tp", "%1<->tp"
-			)
-			return nameCache[name]
-		end
-
-		local staff = {
-			{"admin", "172e0cf7ce5.png"},
-			{"bot", "172e0cf7ce5.png"},
-			{"mod", "173eeb6cd94.png"},
-			{"mapper", "17323cc35d1.png"},
-			{"translator", "173f3263916.png"}
-		}
-		local images = {}
-
-		Profile = Interface.new(200, 50, 400, 360, true)
-			:setShowCheck(function(self, player, profile, data)
-				local file = data or players_file[profile]
-				return (file
-						and file.v == data_version)
-			end)
-
-			:addImage({
-				image = "178de11fd0c.png",
-				target = ":1",
-				x = -5, y = -5
-			})
-
-			:addTextArea({
-				alpha = 0,
-				x = 5, y = 5,
-				height = 100,
-				canUpdate = true,
-				text = function(self, player, profile)
-					return "<font size='20' face='Verdana'><v><b>" .. formatName(profile)
-				end
-			})
-			:addTextArea({
-				x = 10, y = 45, height = 1, width = 380,
-				border = 0x9d7043
-			})
-			:addTextArea({
-				x = 5, y = 47, height = 1, width = 390,
-				color = {0x1c3a3e, 0x1c3a3e, 1}
-			})
-
-			:onUpdate(function(self, player, profile, data)
-				local container = images[player]
-				if not container then
-					container = {_count = 0}
-					images[player] = container
-				else
-					for index = 1, container._count do
-						tfm.exec.removeImage(container[index])
-					end
-					container._count = 0
-				end
-
-				local x = self.x + 370
-				if not (data or players_file[profile]).hidden then
-					for index = 1, #staff do
-						if ranks[ staff[index][1] ][profile] then
-							container._count = container._count + 1
-							container[ container._count ] = tfm.exec.addImage(staff[index][2], "&1", x, self.y + 10, player)
-							x = x - 25
-						end
-					end
-				end
-
-				x = self.x + 15
-				local limit = x + 40 * 9
-				local y = self.y + 205
-				local pbg = (data or players_file[profile]).badges
-				if pbg then
-					local badge
-					for index = 1, #badges do
-						if pbg[index] > 0 then
-							badge = badges[index][pbg[index]]
-
-							container._count = container._count + 1
-							container[ container._count ] = tfm.exec.addImage(badge[2], ":2", x, y, player)
-							ui.addTextArea(
-								-10000 - index,
-								"<a href='event:_help:badge_" .. badge[1] .. "'>\n\n\n\n\n\n",
-								player, x, y, 30, 30,
-								0, 0, 0, true
-							)
-
-							x = x + 40
-							if x >= limit then
-								x = self.x + 15
-								y = y + 40
-							end
-						else
-							ui.removeTextArea(-10000 - index, player)
-						end
-					end
-				end
-			end)
-			:onRemove(function(self, player, profile)
-				for index = 1, images[player]._count do
-					tfm.exec.removeImage(images[player][index])
-				end
-				for index = 1, #badges do
-					ui.removeTextArea(-10000 - index, player)
-				end
-				images[player]._count = 0
-			end)
-
-			:addTextArea({
-				x = 5, y = 50,
-				canUpdate = true,
-				text = function(self, player, profile, data)
-					local file = (data or players_file[profile])
-					local displayStats = (not file.private_maps or player == profile or (perms[player] and perms[player].see_private_maps))
-
-					return translatedMessage(
-						"profile", player,
-						file.private_maps and translatedMessage("private_maps", player) or "",
-
-						displayStats and translatedMessage("map_count", player, file.c, file.week[1], #file.hour) or "",
-
-						profile == player and string.format(
-							"<a href='event:prof_maps:%s'><j>[%s]</j></a>",
-							file.private_maps and "public" or "private",
-							translatedMessage(file.private_maps and "make_public" or "make_private", player)
-						) or "",
-
-						leaderboard[profile] and ("#" .. leaderboard[profile]) or "N/A",
-
-						weekleaderboard[profile] and ("#" .. weekleaderboard[profile]) or "N/A",
-
-						displayStats and translatedMessage("title_count", player, file.tc, file.cc) or ""
-					)
-				end,
-				alpha = 0, height = 150
-			})
-
-			:addTextArea({
-				x = 5, y = 175,
-				canUpdate = true,
-				text = function(self, player, profile, data)
-					local count = 0
-					local pbg = (data or players_file[profile]).badges
-					if pbg then
-						for index = 1, #badges do
-							if pbg[index] > 0 then
-								count = count + 1
-							end
-						end
-					end
-					return translatedMessage("badges", player, count)
-				end,
-				height = 20,
-				alpha = 0
-			})
-
-			:loadComponent(
-				Button.new():setTranslation("close")
-				:onClick(function(self, player)
-					self.parent:remove(player)
-				end)
-				:setPosition(10, 300):setSize(380, 15)
-			)
-
-		onEvent("ParsedTextAreaCallback", function(id, player, action, args)
-			if action == "prof_maps" then
-				if not checkCooldown(player, "mapsToggle", 500) then return end
-
-				if args == "public" then
-					players_file[player].private_maps = nil
-				else
-					players_file[player].private_maps = true
-				end
-
-				savePlayerData(player)
-
-				if Profile.open[player] then
-					Profile:update(player, player)
-				end
-			end
-		end)
-	end
-	--[[ End of file modes/parkour/interfaces/profile.lua ]]--
 	--[[ File modes/parkour/interfaces/staff.lua ]]--
 	local Staff
 	do
@@ -9134,265 +8972,6 @@ local function initialize_parkour() -- so it uses less space after building
 		Staff.sorted_members = {}
 	end
 	--[[ End of file modes/parkour/interfaces/staff.lua ]]--
-	--[[ File modes/parkour/interfaces/poll.lua ]]--
-	local polls
-	do
-		polls = {}
-
-		local pollSizes = {
-			tiny = {
-				{200, 130, 400, 140, true},
-				minOptions = 2,
-				maxOptions = 2,
-				optionY = 85
-			},
-
-			small = {
-				{200, 100, 400, 200, true},
-				minOptions = 2,
-				maxOptions = 4,
-				optionY = 85
-			},
-
-			medium = {
-				{200, 80, 400, 260, true},
-				minOptions = 2,
-				maxOptions = 6,
-				optionY = 85
-			},
-
-			big = {
-				{200, 50, 400, 320, true},
-				minOptions = 2,
-				maxOptions = 8,
-				optionY = 85
-			}
-		}
-
-		local poll, offset
-		for name, data in next, pollSizes do
-			polls[name] = {}
-
-			for options = data.minOptions, data.maxOptions do
-				local text_fnc = function(self, player, translation, title)
-					local text
-					if translation then
-						text = translatedMessage(title, player)
-					else
-						text = title
-					end
-					return "<font size='13'><v>[#parkour]</v> " .. text
-				end
-
-				result = Interface.new(table.unpack(data[1]))
-				result.y = result.y - 15
-
-				result.height = result.height + 30
-				result:loadTemplate(WindowBackground)
-					:addTextArea({
-						alpha = 0, y = 0,
-						text = text_fnc
-					})
-
-				poll = Interface.new(table.unpack(data[1]))
-					:loadTemplate(WindowBackground)
-					:addTextArea({
-						alpha = 0, y = 0,
-						text = text_fnc
-					})
-
-				offset = data.optionY + 30 * (data.maxOptions - options)
-
-				for button = 1, options do
-					local component = Button.new():setText(function(self, player, translation, title, buttons, results)
-							local text
-							if translation then
-								text = translatedMessage(buttons[button], player)
-							else
-								text = buttons[button]
-							end
-
-							if results then
-								local percentage = 100 * results[button] / results.total
-								if percentage ~= percentage then -- NaN
-									percentage = 0
-								end
-
-								return string.format(text .. " - %.2f%% (%s)", percentage, results[button])
-							end
-							return text
-						end)
-
-						:canUpdate(true):onUpdate(function(self, player, translation, title, buttons, results)
-							if results then
-								self:disable(player)
-							else
-								self:enable(player)
-							end
-						end)
-
-						:onClick(function(self, player)
-							if eventPollVote then
-								eventPollVote(self.parent, player, button)
-							end
-						end)
-
-						:setPosition(10, offset):setSize(poll.width - 20, 15)
-
-					result:loadComponent(component)
-					poll:loadComponent(component)
-					offset = offset + 30
-				end
-
-				result:loadComponent(
-					Button.new():setTranslation("close")
-
-					:onClick(function(self, player)
-						self.parent:remove(player)
-					end)
-
-					:setPosition(10, offset):setSize(poll.width - 20, 15)
-				)
-
-				poll.closer = result
-				polls[name][options] = poll
-			end
-		end
-	end
-	--[[ End of file modes/parkour/interfaces/poll.lua ]]--
-	--[[ File modes/parkour/interfaces/options.lua ]]--
-	local no_help
-	local OptionsInterface = Interface.new(168, 46, 465, 330, true)
-		:loadTemplate(WindowBackground)
-
-		:addTextArea({
-			translation = "options",
-			alpha = 0
-		})
-		:loadComponent(
-			Button.new():setTranslation("close")
-			:onClick(function(self, player)
-				self.parent:remove(player)
-			end)
-			:setPosition(10, 305):setSize(445, 15)
-		)
-		:onRemove(function(self, player)
-			savePlayerData(player)
-		end)
-
-		:loadComponent(
-			Toggle.new(435, 55, false)
-			:onToggle(function(self, player, state) -- qwerty or azerty keyboard
-				players_file[player].settings[5] = state and 1 or 0
-
-				if victory[player] then
-					unbind(player)
-					if not no_powers[player] then
-						bindNecessary(player)
-					end
-				end
-			end)
-			:onUpdate(function(self, player)
-				local setting = players_file[player].settings[5] == 1
-				if (self.state[player] and not setting) or (not self.state[player] and setting) then
-					self:toggle(player)
-				end
-			end)
-		)
-		:loadComponent(
-			Toggle.new(435, 81, false)
-			:onToggle(function(self, player, state) -- M or DEL for mort
-				players_file[player].settings[2] = state and 1 or 0
-
-				if state then
-					bindKeyboard(player, 77, true, true)
-					bindKeyboard(player, 46, true, false)
-				else
-					bindKeyboard(player, 77, true, false)
-					bindKeyboard(player, 46, true, true)
-				end
-			end)
-			:onUpdate(function(self, player)
-				local setting = players_file[player].settings[2] == 1
-				if (self.state[player] and not setting) or (not self.state[player] and setting) then
-					self:toggle(player)
-				end
-			end)
-		)
-		:loadComponent(
-			Toggle.new(435, 107, false)
-			:onToggle(function(self, player, state) -- powers cooldown
-				players_file[player].settings[3] = state and 1 or 0
-			end)
-			:onUpdate(function(self, player)
-				local setting = players_file[player].settings[3] == 1
-				if (self.state[player] and not setting) or (not self.state[player] and setting) then
-					self:toggle(player)
-				end
-			end)
-		)
-		:loadComponent(
-			Toggle.new(435, 133, false)
-			:onToggle(function(self, player, state) -- powers button
-				players_file[player].settings[4] = state and 1 or 0
-
-				GameInterface:update(player)
-			end)
-			:onUpdate(function(self, player)
-				local setting = players_file[player].settings[4] == 1
-				if (self.state[player] and not setting) or (not self.state[player] and setting) then
-					self:toggle(player)
-				end
-			end)
-		)
-		:loadComponent(
-			Toggle.new(435, 159, false)
-			:onToggle(function(self, player, state) -- help button
-				players_file[player].settings[6] = state and 1 or 0
-
-				GameInterface:update(player)
-			end)
-			:onUpdate(function(self, player)
-				local setting = players_file[player].settings[6] == 1
-				if (self.state[player] and not setting) or (not self.state[player] and setting) then
-					self:toggle(player)
-				end
-			end)
-		)
-		:loadComponent(
-			Toggle.new(435, 185, false)
-			:onToggle(function(self, player, state) -- congrats messages
-				players_file[player].settings[7] = state and 1 or 0
-			end)
-			:onUpdate(function(self, player)
-				local setting = players_file[player].settings[7] == 1
-				if (self.state[player] and not setting) or (not self.state[player] and setting) then
-					self:toggle(player)
-				end
-			end)
-		)
-		:loadComponent(
-			Toggle.new(435, 211, false)
-			:onToggle(function(self, player, state) -- no help indicator
-				players_file[player].settings[8] = state and 1 or 0
-
-				if not state then
-					if no_help[player] then
-						tfm.exec.removeImage(no_help[player])
-						no_help[player] = nil
-					end
-				else
-					no_help[player] = tfm.exec.addImage("1722eeef19f.png", "$" .. player, -10, -35)
-				end
-			end)
-			:onUpdate(function(self, player)
-				local setting = players_file[player].settings[8] == 1
-				if (self.state[player] and not setting) or (not self.state[player] and setting) then
-					self:toggle(player)
-				end
-			end)
-		)
-	--[[ End of file modes/parkour/interfaces/options.lua ]]--
 	--[[ File modes/parkour/interfaces/leaderboard.lua ]]--
 	local LeaderboardInterface
 	do
@@ -9656,6 +9235,200 @@ local function initialize_parkour() -- so it uses less space after building
 			)
 	end
 	--[[ End of file modes/parkour/interfaces/leaderboard.lua ]]--
+	--[[ File modes/parkour/interfaces/profile.lua ]]--
+	local Profile
+	do
+		local nameCache = {}
+		local function formatName(name)
+			if nameCache[name] then
+				return nameCache[name]
+			end
+
+			nameCache[name] = string.gsub(
+				string.gsub(name, "(#%d%d%d%d)", "<font size='15'><g>%1</g></font>"),
+				"([Hh]t)tp", "%1<->tp"
+			)
+			return nameCache[name]
+		end
+
+		local staff = {
+			{"admin", "172e0cf7ce5.png"},
+			{"bot", "172e0cf7ce5.png"},
+			{"mod", "173eeb6cd94.png"},
+			{"mapper", "17323cc35d1.png"},
+			{"translator", "173f3263916.png"}
+		}
+		local images = {}
+
+		Profile = Interface.new(200, 50, 400, 360, true)
+			:setShowCheck(function(self, player, profile, data)
+				local file = data or players_file[profile]
+				return (file
+						and file.v == data_version)
+			end)
+
+			:addImage({
+				image = "178de11fd0c.png",
+				target = ":1",
+				x = -5, y = -5
+			})
+
+			:addTextArea({
+				alpha = 0,
+				x = 5, y = 5,
+				height = 100,
+				canUpdate = true,
+				text = function(self, player, profile)
+					return "<font size='20' face='Verdana'><v><b>" .. formatName(profile)
+				end
+			})
+			:addTextArea({
+				x = 10, y = 45, height = 1, width = 380,
+				border = 0x9d7043
+			})
+			:addTextArea({
+				x = 5, y = 47, height = 1, width = 390,
+				color = {0x1c3a3e, 0x1c3a3e, 1}
+			})
+
+			:onUpdate(function(self, player, profile, data)
+				local container = images[player]
+				if not container then
+					container = {_count = 0}
+					images[player] = container
+				else
+					for index = 1, container._count do
+						tfm.exec.removeImage(container[index])
+					end
+					container._count = 0
+				end
+
+				local x = self.x + 370
+				if not (data or players_file[profile]).hidden then
+					for index = 1, #staff do
+						if ranks[ staff[index][1] ][profile] then
+							container._count = container._count + 1
+							container[ container._count ] = tfm.exec.addImage(staff[index][2], "&1", x, self.y + 10, player)
+							x = x - 25
+						end
+					end
+				end
+
+				x = self.x + 15
+				local limit = x + 40 * 9
+				local y = self.y + 205
+				local pbg = (data or players_file[profile]).badges
+				if pbg then
+					local badge
+					for index = 1, #badges do
+						if pbg[index] > 0 then
+							badge = badges[index][pbg[index]]
+
+							container._count = container._count + 1
+							container[ container._count ] = tfm.exec.addImage(badge[2], ":2", x, y, player)
+							ui.addTextArea(
+								-10000 - index,
+								"<a href='event:_help:badge_" .. badge[1] .. "'>\n\n\n\n\n\n",
+								player, x, y, 30, 30,
+								0, 0, 0, true
+							)
+
+							x = x + 40
+							if x >= limit then
+								x = self.x + 15
+								y = y + 40
+							end
+						else
+							ui.removeTextArea(-10000 - index, player)
+						end
+					end
+				end
+			end)
+			:onRemove(function(self, player, profile)
+				for index = 1, images[player]._count do
+					tfm.exec.removeImage(images[player][index])
+				end
+				for index = 1, #badges do
+					ui.removeTextArea(-10000 - index, player)
+				end
+				images[player]._count = 0
+			end)
+
+			:addTextArea({
+				x = 5, y = 50,
+				canUpdate = true,
+				text = function(self, player, profile, data)
+					local file = (data or players_file[profile])
+					local displayStats = (not file.private_maps or player == profile or (perms[player] and perms[player].see_private_maps))
+
+					return translatedMessage(
+						"profile", player,
+						file.private_maps and translatedMessage("private_maps", player) or "",
+
+						displayStats and translatedMessage("map_count", player, file.c, file.week[1], #file.hour) or "",
+
+						profile == player and string.format(
+							"<a href='event:prof_maps:%s'><j>[%s]</j></a>",
+							file.private_maps and "public" or "private",
+							translatedMessage(file.private_maps and "make_public" or "make_private", player)
+						) or "",
+
+						leaderboard[profile] and ("#" .. leaderboard[profile]) or "N/A",
+
+						weekleaderboard[profile] and ("#" .. weekleaderboard[profile]) or "N/A",
+
+						displayStats and translatedMessage("title_count", player, file.tc, file.cc) or ""
+					)
+				end,
+				alpha = 0, height = 150
+			})
+
+			:addTextArea({
+				x = 5, y = 175,
+				canUpdate = true,
+				text = function(self, player, profile, data)
+					local count = 0
+					local pbg = (data or players_file[profile]).badges
+					if pbg then
+						for index = 1, #badges do
+							if pbg[index] > 0 then
+								count = count + 1
+							end
+						end
+					end
+					return translatedMessage("badges", player, count)
+				end,
+				height = 20,
+				alpha = 0
+			})
+
+			:loadComponent(
+				Button.new():setTranslation("close")
+				:onClick(function(self, player)
+					self.parent:remove(player)
+				end)
+				:setPosition(10, 300):setSize(380, 15)
+			)
+
+		onEvent("ParsedTextAreaCallback", function(id, player, action, args)
+			if action == "prof_maps" then
+				if not checkCooldown(player, "mapsToggle", 500) then return end
+
+				if args == "public" then
+					players_file[player].private_maps = nil
+				else
+					players_file[player].private_maps = true
+				end
+
+				savePlayerData(player)
+
+				if Profile.open[player] then
+					Profile:update(player, player)
+				end
+			end
+		end)
+	end
+	--[[ End of file modes/parkour/interfaces/profile.lua ]]--
 	--[[ File modes/parkour/interfaces/game.lua ]]--
 	do
 		local settings_img = "1713705576b.png"
@@ -9736,6 +9509,16 @@ local function initialize_parkour() -- so it uses less space after building
 			})
 	end
 	--[[ End of file modes/parkour/interfaces/game.lua ]]--
+	--[[ File modes/parkour/interfaces/afk.lua ]]--
+	AfkInterface = Interface.new(100, 50, 600, 300, true)
+		:loadTemplate(WindowBackground)
+		:addTextArea({
+			x = 0, y = 0,
+			width = 600, height = 300,
+			alpha = 0,
+			translation = "afk_popup"
+		})
+	--[[ End of file modes/parkour/interfaces/afk.lua ]]--
 	--[[ File modes/parkour/interfaces/powers.lua ]]--
 	local PowersInterface
 	do
@@ -10228,57 +10011,158 @@ local function initialize_parkour() -- so it uses less space after building
 		end)
 	end
 	--[[ End of file modes/parkour/interfaces/powers.lua ]]--
-	--[[ File modes/parkour/interfaces/afk.lua ]]--
-	AfkInterface = Interface.new(100, 50, 600, 300, true)
+	--[[ File modes/parkour/interfaces/options.lua ]]--
+	local no_help
+	local OptionsInterface = Interface.new(168, 46, 465, 330, true)
 		:loadTemplate(WindowBackground)
+
 		:addTextArea({
-			x = 0, y = 0,
-			width = 600, height = 300,
-			alpha = 0,
-			translation = "afk_popup"
+			translation = "options",
+			alpha = 0
 		})
-	--[[ End of file modes/parkour/interfaces/afk.lua ]]--
-	--[[ File modes/parkour/interfaces/tracker.lua ]]--
-	local PowerTracker
+		:loadComponent(
+			Button.new():setTranslation("close")
+			:onClick(function(self, player)
+				self.parent:remove(player)
+			end)
+			:setPosition(10, 305):setSize(445, 15)
+		)
+		:onRemove(function(self, player)
+			savePlayerData(player)
+		end)
+
+		:loadComponent(
+			Toggle.new(435, 55, false)
+			:onToggle(function(self, player, state) -- qwerty or azerty keyboard
+				players_file[player].settings[5] = state and 1 or 0
+
+				if victory[player] then
+					unbind(player)
+					if not no_powers[player] then
+						bindNecessary(player)
+					end
+				end
+			end)
+			:onUpdate(function(self, player)
+				local setting = players_file[player].settings[5] == 1
+				if (self.state[player] and not setting) or (not self.state[player] and setting) then
+					self:toggle(player)
+				end
+			end)
+		)
+		:loadComponent(
+			Toggle.new(435, 81, false)
+			:onToggle(function(self, player, state) -- M or DEL for mort
+				players_file[player].settings[2] = state and 1 or 0
+
+				if state then
+					bindKeyboard(player, 77, true, true)
+					bindKeyboard(player, 46, true, false)
+				else
+					bindKeyboard(player, 77, true, false)
+					bindKeyboard(player, 46, true, true)
+				end
+			end)
+			:onUpdate(function(self, player)
+				local setting = players_file[player].settings[2] == 1
+				if (self.state[player] and not setting) or (not self.state[player] and setting) then
+					self:toggle(player)
+				end
+			end)
+		)
+		:loadComponent(
+			Toggle.new(435, 107, false)
+			:onToggle(function(self, player, state) -- powers cooldown
+				players_file[player].settings[3] = state and 1 or 0
+			end)
+			:onUpdate(function(self, player)
+				local setting = players_file[player].settings[3] == 1
+				if (self.state[player] and not setting) or (not self.state[player] and setting) then
+					self:toggle(player)
+				end
+			end)
+		)
+		:loadComponent(
+			Toggle.new(435, 133, false)
+			:onToggle(function(self, player, state) -- powers button
+				players_file[player].settings[4] = state and 1 or 0
+
+				GameInterface:update(player)
+			end)
+			:onUpdate(function(self, player)
+				local setting = players_file[player].settings[4] == 1
+				if (self.state[player] and not setting) or (not self.state[player] and setting) then
+					self:toggle(player)
+				end
+			end)
+		)
+		:loadComponent(
+			Toggle.new(435, 159, false)
+			:onToggle(function(self, player, state) -- help button
+				players_file[player].settings[6] = state and 1 or 0
+
+				GameInterface:update(player)
+			end)
+			:onUpdate(function(self, player)
+				local setting = players_file[player].settings[6] == 1
+				if (self.state[player] and not setting) or (not self.state[player] and setting) then
+					self:toggle(player)
+				end
+			end)
+		)
+		:loadComponent(
+			Toggle.new(435, 185, false)
+			:onToggle(function(self, player, state) -- congrats messages
+				players_file[player].settings[7] = state and 1 or 0
+			end)
+			:onUpdate(function(self, player)
+				local setting = players_file[player].settings[7] == 1
+				if (self.state[player] and not setting) or (not self.state[player] and setting) then
+					self:toggle(player)
+				end
+			end)
+		)
+		:loadComponent(
+			Toggle.new(435, 211, false)
+			:onToggle(function(self, player, state) -- no help indicator
+				players_file[player].settings[8] = state and 1 or 0
+
+				if not state then
+					if no_help[player] then
+						tfm.exec.removeImage(no_help[player])
+						no_help[player] = nil
+					end
+				else
+					no_help[player] = tfm.exec.addImage("1722eeef19f.png", "$" .. player, -10, -35)
+				end
+			end)
+			:onUpdate(function(self, player)
+				local setting = players_file[player].settings[8] == 1
+				if (self.state[player] and not setting) or (not self.state[player] and setting) then
+					self:toggle(player)
+				end
+			end)
+		)
+	--[[ End of file modes/parkour/interfaces/options.lua ]]--
+	--[[ File modes/parkour/interfaces/newbadge.lua ]]--
 	do
-		local nameCache = {}
-		local function formatName(name)
-			if nameCache[name] then
-				return nameCache[name]
-			end
-
-			nameCache[name] = string.gsub(
-				string.gsub(name, "(#%d%d%d%d)", "<font size='10'><g>%1</g></font>"),
-				"([Hh]t)tp", "%1<->tp"
-			)
-			return nameCache[name]
-		end
-
-		PowerTracker = Interface.new(200, 50, 400, 300, true)
+		NewBadgeInterface = Interface.new(340, 130, 120, 140, true)
 			:loadTemplate(WindowBackground)
 
-			:addTextArea({
-				alpha = 0,
-				text = "<p align='center'><font size='14'><cep><b>Power Tracker</b></cep></font></p>"
-			})
-
-			:addTextArea({
-				canUpdate = true,
-				y = 25, height = 240,
-				alpha = 0,
-
-				text = function(self, player, powers)
-					local pieces, count = {}, 0
-
-					local power
-					for index = powers._count, math.max(powers._count - 18, 1), -1 do
-						power = powers[index]
-						count = count + 1
-						pieces[count] = formatName(power[1]) .. "<n> -> </n>" .. power[2]
-					end
-
-					return "<v>" .. table.concat(pieces, "\n")
+			:setShowCheck(function(self, player, group, badge)
+				if self.open[player] then
+					self:update(player, group, badge)
+					return false
 				end
+				return true
+			end)
+
+			:addImage({
+				image = function(self, player, group, badge)
+					return badges[group][badge][3]
+				end,
+				target = "&1",
+				x = 10, y = 5
 			})
 
 			:loadComponent(
@@ -10288,10 +10172,136 @@ local function initialize_parkour() -- so it uses less space after building
 					self.parent:remove(player)
 				end)
 
-				:setPosition(10, 275):setSize(380, 15)
+				:setSize(100, 15):setPosition(10, 115)
 			)
 	end
-	--[[ End of file modes/parkour/interfaces/tracker.lua ]]--
+	--[[ End of file modes/parkour/interfaces/newbadge.lua ]]--
+	--[[ File modes/parkour/interfaces/poll.lua ]]--
+	local polls
+	do
+		polls = {}
+
+		local pollSizes = {
+			tiny = {
+				{200, 130, 400, 140, true},
+				minOptions = 2,
+				maxOptions = 2,
+				optionY = 85
+			},
+
+			small = {
+				{200, 100, 400, 200, true},
+				minOptions = 2,
+				maxOptions = 4,
+				optionY = 85
+			},
+
+			medium = {
+				{200, 80, 400, 260, true},
+				minOptions = 2,
+				maxOptions = 6,
+				optionY = 85
+			},
+
+			big = {
+				{200, 50, 400, 320, true},
+				minOptions = 2,
+				maxOptions = 8,
+				optionY = 85
+			}
+		}
+
+		local poll, offset
+		for name, data in next, pollSizes do
+			polls[name] = {}
+
+			for options = data.minOptions, data.maxOptions do
+				local text_fnc = function(self, player, translation, title)
+					local text
+					if translation then
+						text = translatedMessage(title, player)
+					else
+						text = title
+					end
+					return "<font size='13'><v>[#parkour]</v> " .. text
+				end
+
+				result = Interface.new(table.unpack(data[1]))
+				result.y = result.y - 15
+
+				result.height = result.height + 30
+				result:loadTemplate(WindowBackground)
+					:addTextArea({
+						alpha = 0, y = 0,
+						text = text_fnc
+					})
+
+				poll = Interface.new(table.unpack(data[1]))
+					:loadTemplate(WindowBackground)
+					:addTextArea({
+						alpha = 0, y = 0,
+						text = text_fnc
+					})
+
+				offset = data.optionY + 30 * (data.maxOptions - options)
+
+				for button = 1, options do
+					local component = Button.new():setText(function(self, player, translation, title, buttons, results)
+							local text
+							if translation then
+								text = translatedMessage(buttons[button], player)
+							else
+								text = buttons[button]
+							end
+
+							if results then
+								local percentage = 100 * results[button] / results.total
+								if percentage ~= percentage then -- NaN
+									percentage = 0
+								end
+
+								return string.format(text .. " - %.2f%% (%s)", percentage, results[button])
+							end
+							return text
+						end)
+
+						:canUpdate(true):onUpdate(function(self, player, translation, title, buttons, results)
+							if results then
+								self:disable(player)
+							else
+								self:enable(player)
+							end
+						end)
+
+						:onClick(function(self, player)
+							if eventPollVote then
+								eventPollVote(self.parent, player, button)
+							end
+						end)
+
+						:setPosition(10, offset):setSize(poll.width - 20, 15)
+
+					result:loadComponent(component)
+					poll:loadComponent(component)
+					offset = offset + 30
+				end
+
+				result:loadComponent(
+					Button.new():setTranslation("close")
+
+					:onClick(function(self, player)
+						self.parent:remove(player)
+					end)
+
+					:setPosition(10, offset):setSize(poll.width - 20, 15)
+				)
+
+				poll.closer = result
+				polls[name][options] = poll
+			end
+		end
+	end
+	--[[ End of file modes/parkour/interfaces/poll.lua ]]--
 	--[[ End of directory modes/parkour/interfaces ]]--
 	--[[ File modes/parkour/ui.lua ]]--
 	-- Stuff related to the keyboard and game interface (not chat)

--- a/modes/parkour/chat-ui.lua
+++ b/modes/parkour/chat-ui.lua
@@ -184,7 +184,7 @@ onEvent("ParsedChatCommand", function(player, cmd, quantity, args)
 		return
 
 	elseif cmd == "submit" then
-		--[[if not records_admins then return end
+		if not records_admins then return end
 		local map = tonumber(string.sub(room.currentMap, 2))
 
 		if fastest.player ~= player then
@@ -228,10 +228,7 @@ onEvent("ParsedChatCommand", function(player, cmd, quantity, args)
 			 room.shortName .. "\000" ..
 			 checkpoint_info.version)
 		)
-		tfm.exec.chatMessage("<v>[#] <d>Your record will be submitted shortly.", player)]]
-
-		tfm.exec.chatMessage("<v>[#] <d>Sorry, record submissions will be disabled until further notice.", player)
-		return
+		tfm.exec.chatMessage("<v>[#] <d>Your record will be submitted shortly.", player)
 
 	elseif cmd == "pause" then -- logged
 		if not ranks.admin[player] then return end

--- a/modes/parkour/game.lua
+++ b/modes/parkour/game.lua
@@ -211,6 +211,7 @@ onEvent("Keyboard", function(player, key)
 		if players_level[player] == 1 and not times.generated[player] then
 			times.generated[player] = now
 			times.checkpoint[player] = now
+			tfm.exec.freezePlayer(player, false)
 		end
 		times.movement[player] = now
 
@@ -304,6 +305,12 @@ onEvent("PlayerRespawn", function(player)
 	if bans[room.playerList[player].id] then return tfm.exec.killPlayer(player) end
 	if (not levels) or (not players_level[player]) then return end
 
+	if (players_level[player] == 1
+		and not times.generated[player]
+		and records_admins) then
+		tfm.exec.freezePlayer(player, true)
+	end
+
 	local level = levels[ players_level[player] ]
 	if not level then return end
 	tfm.exec.movePlayer(player, level.x, level.y)
@@ -347,6 +354,12 @@ onEvent("NewGame", function()
 			players_level[player] = 1
 			changePlayerSize(player, size)
 			tfm.exec.setPlayerScore(player, 1, false)
+		end
+
+		if records_admins then
+			for player in next, in_room do
+				tfm.exec.freezePlayer(player, true)
+			end
 		end
 	end
 


### PR DESCRIPTION
The `!submit` command has been enabled in records room, again
Now players are frozen (only in records rooms) before starting, to prevent this exploit: https://streamable.com/br5stq

Players are not frozen in normal rooms, because it is somewhat annoying; but you can enable it in every room by removing the condition that checks if `records_admins` is not `nil`, in `modes/parkour/game.lua`, lines 310 and 359.

This exploit works by not sending the keypress packet to the server until the mouse has moved up to the first or second checkpoint; so the server doesn't start the timer until it is too late.
The patch works by not allowing the player to move (freezing them) until the server acknowledges the timer has started.