### PR TITLE
fix x speed getting set to 0 on fly

### DIFF
--- a/modes/parkour/powers.lua
+++ b/modes/parkour/powers.lua
@@ -164,7 +164,7 @@ powers = {
 		default = {5, 4}, -- SPACE
 
 		fnc = function(player, key, down, x, y)
-			tfm.exec.movePlayer(player, 0, 0, true, 0, -50, false)
+			tfm.exec.movePlayer(player, 0, 0, true, nil, -50, false)
 		end
 	},
 	{


### PR DESCRIPTION
restore old xspeed=0 behavior by setting it to nil