### PR TITLE
allow mappers to spectate for reviews

### DIFF
--- a/modes/parkour/ranks.lua
+++ b/modes/parkour/ranks.lua
@@ -55,6 +55,7 @@ local ranks_permissions = {
 		load_custom_map = true,
 		enable_review = true,
 		hide = true,
+		spectate = true,
 		start_round_poll = true,
 		see_map_polls = true,
 		set_map_time_review = true


### PR DESCRIPTION
this should help them get a first impression on the map, and guide players/authors in a way that can't be done without the help of spec